### PR TITLE
createメソッドの実装とテスト(jest)ファイルの実装

### DIFF
--- a/__test__/models/Todo/create.spec.js
+++ b/__test__/models/Todo/create.spec.js
@@ -1,0 +1,47 @@
+const Todo = require("../../../models/Todo");
+
+describe("createメソッドのテスト", () => {
+  it("メソッド実行時、引数にtitleプロパティを含むオブジェクトがないとエラーになる。", () => {
+    const dataList = [{ body: "詳細文" }];
+    dataList.forEach((data) => {
+      try {
+        Todo.create(data);
+        fail();
+      } catch (error) {
+        expect(error.message).toEqual("titleは必須です");
+      }
+    });
+  });
+
+  it("メソッド実行時、引数にbodyプロパティを含むオブジェクトがないとエラーになる。", () => {
+    const dataList = [{ title: "詳細文" }];
+    dataList.forEach((data) => {
+      try {
+        Todo.create(data);
+        fail();
+      } catch (error) {
+        expect(error.message).toEqual("bodyは必須です");
+      }
+    });
+  });
+
+  it("メソッド実行時、正しい引数を渡すと、新規にTodoデータを作成し、Todo配列にデータを追加する", () => {
+    const oldTodos = Todo.findAll();
+    const data = {
+      title: "ダミータイトル",
+      body: "ダミーボディ",
+    };
+
+    const createTodo = Todo.create(data);
+    expect(createTodo).toEqual({
+      id: createTodo.id,
+      title: data.title,
+      body: data.body,
+      createdAt: createTodo.createdAt,
+      updatedAt: createTodo.updatedAt,
+    });
+
+    const currentTodo = Todo.findAll();
+    expect(oldTodos.length + 1).toEqual(currentTodo.length);
+  });
+});

--- a/__test__/models/Todo/create.spec.js
+++ b/__test__/models/Todo/create.spec.js
@@ -24,4 +24,19 @@ describe("createメソッドのテスト", () => {
       }
     });
   });
+  it("メソッド実行時、正しい引数を渡すと、新規にTodoデータを作成し、Todo配列にデータを追加する", () => {
+    const data = {
+      title: "ダミータイトル",
+      body: "ダミーボディ",
+    };
+
+    const createTodo = Todo.create(data);
+    expect(createTodo).toEqual({
+      id: createTodo.id,
+      title: data.title,
+      body: data.body,
+      createdAt: createTodo.createdAt,
+      updatedAt: createTodo.updatedAt,
+    });
+  });
 });

--- a/__test__/models/Todo/create.spec.js
+++ b/__test__/models/Todo/create.spec.js
@@ -24,24 +24,4 @@ describe("createメソッドのテスト", () => {
       }
     });
   });
-
-  it("メソッド実行時、正しい引数を渡すと、新規にTodoデータを作成し、Todo配列にデータを追加する", () => {
-    const oldTodos = Todo.findAll();
-    const data = {
-      title: "ダミータイトル",
-      body: "ダミーボディ",
-    };
-
-    const createTodo = Todo.create(data);
-    expect(createTodo).toEqual({
-      id: createTodo.id,
-      title: data.title,
-      body: data.body,
-      createdAt: createTodo.createdAt,
-      updatedAt: createTodo.updatedAt,
-    });
-
-    const currentTodo = Todo.findAll();
-    expect(oldTodos.length + 1).toEqual(currentTodo.length);
-  });
 });

--- a/models/Todo.js
+++ b/models/Todo.js
@@ -12,9 +12,6 @@ class Todo {
 }
 
 module.exports = {
-  findAll: () => {
-    return todos.slice();
-  },
   create: ({ title, body }) => {
     if (!title) {
       throw new Error("titleは必須です");

--- a/models/Todo.js
+++ b/models/Todo.js
@@ -1,0 +1,18 @@
+const todos = [];
+let nextId = 1;
+
+class Todo {
+  constructor({ title, body }) {
+    this.id = nextId++;
+    this.title = title;
+    this.body = body;
+    this.createdAt = new Date();
+    this.updatedAt = new Date();
+  }
+}
+
+module.exports = {
+  findAll: () => {
+    return todos.slice();
+  },
+};

--- a/models/Todo.js
+++ b/models/Todo.js
@@ -15,4 +15,20 @@ module.exports = {
   findAll: () => {
     return todos.slice();
   },
+  create: ({ title, body }) => {
+    if (!title) {
+      throw new Error("titleは必須です");
+    }
+    if (!body) {
+      throw new Error("bodyは必須です");
+    }
+
+    const todo = new Todo({
+      title: title,
+      body: body,
+    });
+    todos.push(todo);
+
+    return todo;
+  },
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
createメソッドの実装とテスト(jest)ファイルの実装を行いました。

findAllメソッドのプルリクエストを作成した際に、
前田さんからfor文で作成した初期データを削除しておくようにとのご指摘がありました。

その実行を、今回作成したブランチで修正をしてしまい、
違うブランチの修正を、今回のブランチで行ってしまうミスをしました。

ブランチを切り替えた際に、一旦ファイルを閉じることを怠ったことによる、単純なミスです。

コミット履歴に、'modes/Todo.js for in addData Delete'が二つあります。
ブランチ間でのコンフリクトが発生しないよう二つのファイルを修正した為です。

以後、気をつけます。



