### PR TITLE
【DB内のTodoを更新する機能を実装】

### DIFF
--- a/__test__/app/api/todos/GetTodosController.spec.ts
+++ b/__test__/app/api/todos/GetTodosController.spec.ts
@@ -1,5 +1,12 @@
-import { TodoEntity } from "../../../../entities/Todo";
 import { requestAPI } from "../../../helper/requestHelper";
+
+type TodoResponseType = {
+  id: number;
+  title: string;
+  body: string;
+  createdAt: Date;
+  updateAt: Date;
+};
 
 describe("getメソッドのテスト(Todo一覧取得APIの動作テスト)", () => {
   beforeAll(async () => {
@@ -22,7 +29,8 @@ describe("getメソッドのテスト(Todo一覧取得APIの動作テスト)", (
       statusCode: 200,
     });
 
-    const todoItems: TodoEntity[] = response.body;
+    const todoItems: TodoResponseType[] = response.body;
+
     expect(todoItems.length).toEqual(3);
     expect(todoItems.map((todo) => todo.id)).toEqual([1, 2, 3]);
     expect(todoItems.map((todo) => todo.title)).toEqual([

--- a/__test__/entities/Todo.spec.ts
+++ b/__test__/entities/Todo.spec.ts
@@ -25,13 +25,13 @@ describe("TodoEntityクラス", () => {
       };
 
       const instance = new TodoEntity(data);
-      const clonedInstance = instance.clone();
+      const sameInstance = instance.clone();
 
-      expect(clonedInstance.getTodoEntity.id).toEqual(1);
-      expect(clonedInstance.getTodoEntity.title).toEqual("ダミータイトル");
-      expect(clonedInstance.getTodoEntity.body).toEqual("ダミーボディ");
-      expect(clonedInstance.getTodoEntity.createdAt).toBeInstanceOf(Date);
-      expect(clonedInstance.getTodoEntity.updatedAt).toBeInstanceOf(Date);
+      expect(sameInstance.getTodoEntity.id).toEqual(1);
+      expect(sameInstance.getTodoEntity.title).toEqual("ダミータイトル");
+      expect(sameInstance.getTodoEntity.body).toEqual("ダミーボディ");
+      expect(sameInstance.getTodoEntity.createdAt).toBeInstanceOf(Date);
+      expect(sameInstance.getTodoEntity.updatedAt).toBeInstanceOf(Date);
     });
 
     it("updateメソッドを実行すると、作成後のTodo情報を更新する事ができる", () => {

--- a/__test__/entities/Todo.spec.ts
+++ b/__test__/entities/Todo.spec.ts
@@ -1,3 +1,4 @@
+import { json } from "express";
 import { TodoEntity } from "../../entities/Todo";
 
 describe("TodoEntityクラス", () => {
@@ -25,16 +26,18 @@ describe("TodoEntityクラス", () => {
       };
 
       const instance = new TodoEntity(data);
-      const sameInstance = instance.clone();
+      const clonedInstance = instance.clone();
 
-      expect(sameInstance.getTodoEntity.id).toEqual(1);
-      expect(sameInstance.getTodoEntity.title).toEqual("ダミータイトル");
-      expect(sameInstance.getTodoEntity.body).toEqual("ダミーボディ");
-      expect(sameInstance.getTodoEntity.createdAt).toBeInstanceOf(Date);
-      expect(sameInstance.getTodoEntity.updatedAt).toBeInstanceOf(Date);
+      expect(clonedInstance.getTodoEntity.id).toEqual(1);
+      expect(clonedInstance.getTodoEntity.title).toEqual("ダミータイトル");
+      expect(clonedInstance.getTodoEntity.body).toEqual("ダミーボディ");
+      expect(clonedInstance.getTodoEntity.createdAt).toBeInstanceOf(Date);
+      expect(clonedInstance.getTodoEntity.updatedAt).toBeInstanceOf(Date);
+
+      expect(instance !== clonedInstance).toBeTruthy();
     });
 
-    it("updateメソッドを実行すると、作成後のTodo情報を更新する事ができる", () => {
+    it("updateメソッドを実行すると、Todo情報(titleの内容)を更新する事ができる", () => {
       const data = {
         id: 1,
         title: "ダミータイトル",
@@ -44,14 +47,46 @@ describe("TodoEntityクラス", () => {
       const instance = new TodoEntity(data);
       instance.update({
         title: "変更後のタイトル",
-        body: "変更後のボディ",
+        body: "ダミーボディ",
       });
 
       expect(instance.getTodoEntity.id).toEqual(1);
       expect(instance.getTodoEntity.title).toEqual("変更後のタイトル");
+      expect(instance.getTodoEntity.body).toEqual("ダミーボディ");
+      expect(instance.getTodoEntity.createdAt).toBeInstanceOf(Date);
+      expect(instance.getTodoEntity.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it("updateメソッドを実行すると、Todo情報(ボディの内容)を更新する事ができる", () => {
+      const data = {
+        id: 1,
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+      };
+
+      const instance = new TodoEntity(data);
+      instance.update({
+        title: "ダミータイトル",
+        body: "変更後のボディ",
+      });
+
+      expect(instance.getTodoEntity.id).toEqual(1);
+      expect(instance.getTodoEntity.title).toEqual("ダミータイトル");
       expect(instance.getTodoEntity.body).toEqual("変更後のボディ");
       expect(instance.getTodoEntity.createdAt).toBeInstanceOf(Date);
       expect(instance.getTodoEntity.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it("getTodoEntityを実行すると、インスタンスのプロパティの値をオブジェクトで取得できる", () => {
+      const data = {
+        id: 1,
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+      };
+      const instance = new TodoEntity(data);
+
+      expect(instance).toBeInstanceOf(TodoEntity);
+      expect(instance.getTodoEntity).toBeInstanceOf(Object);
     });
   });
   describe("異常パターン", () => {
@@ -79,7 +114,7 @@ describe("TodoEntityクラス", () => {
       }).toThrow("bodyの内容は必須です");
     });
 
-    it("タイトルが未入力だと、Todo情報の更新を中断する", () => {
+    it("更新データがない場合、Todo情報の更新を中断する", () => {
       const data = {
         id: 1,
         title: "ダミータイトル",
@@ -88,21 +123,8 @@ describe("TodoEntityクラス", () => {
 
       const instance = new TodoEntity(data);
       expect(() => {
-        instance.update({ title: "", body: "変更後のボディ" });
-      }).toThrow("更新処理を中断(titleの更新データがない為)");
-    });
-
-    it("ボディが未入力だと、Todo情報の更新を中断する", () => {
-      const data = {
-        id: 1,
-        title: "ダミータイトル",
-        body: "ダミーボディ",
-      };
-
-      const instance = new TodoEntity(data);
-      expect(() => {
-        instance.update({ title: "変更後のタイトル", body: "" });
-      }).toThrow("更新処理を中断(bodyの更新データがない為)");
+        instance.update({ title: "", body: "" });
+      }).toThrow("更新処理を中断(更新データがない為)");
     });
   });
 });

--- a/__test__/entities/Todo.spec.ts
+++ b/__test__/entities/Todo.spec.ts
@@ -1,4 +1,3 @@
-import { json } from "express";
 import { TodoEntity } from "../../entities/Todo";
 
 describe("TodoEntityクラス", () => {

--- a/__test__/entities/Todo.spec.ts
+++ b/__test__/entities/Todo.spec.ts
@@ -1,42 +1,108 @@
 import { TodoEntity } from "../../entities/Todo";
 
 describe("TodoEntityクラス", () => {
-  it("タイトルが未入力だとエラーになる", () => {
-    const data = {
-      id: 1,
-      title: "",
-      body: "ダミーボディ",
-    };
+  describe("正常パターン", () => {
+    it("タイトルとボディに入力内容(1文字以上)があれば、Todo情報を作成する事ができる", () => {
+      const data = {
+        id: 1,
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+      };
 
-    expect(() => {
-      new TodoEntity(data);
-    }).toThrow("titleの内容は必須です");
+      const instance = new TodoEntity(data);
+      expect(instance.getTodoEntity.id).toEqual(1);
+      expect(instance.getTodoEntity.title).toEqual("ダミータイトル");
+      expect(instance.getTodoEntity.body).toEqual("ダミーボディ");
+      expect(instance.getTodoEntity.createdAt).toBeInstanceOf(Date);
+      expect(instance.getTodoEntity.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it("cloneメソッドを実行すると、Todoデータのコピーした値を返す", () => {
+      const data = {
+        id: 1,
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+      };
+
+      const instance = new TodoEntity(data);
+      const clonedInstance = instance.clone();
+
+      expect(clonedInstance.getTodoEntity.id).toEqual(1);
+      expect(clonedInstance.getTodoEntity.title).toEqual("ダミータイトル");
+      expect(clonedInstance.getTodoEntity.body).toEqual("ダミーボディ");
+      expect(clonedInstance.getTodoEntity.createdAt).toBeInstanceOf(Date);
+      expect(clonedInstance.getTodoEntity.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it("updateメソッドを実行すると、作成後のTodo情報を更新する事ができる", () => {
+      const data = {
+        id: 1,
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+      };
+
+      const instance = new TodoEntity(data);
+      instance.update({
+        title: "変更後のタイトル",
+        body: "変更後のボディ",
+      });
+
+      expect(instance.getTodoEntity.id).toEqual(1);
+      expect(instance.getTodoEntity.title).toEqual("変更後のタイトル");
+      expect(instance.getTodoEntity.body).toEqual("変更後のボディ");
+      expect(instance.getTodoEntity.createdAt).toBeInstanceOf(Date);
+      expect(instance.getTodoEntity.updatedAt).toBeInstanceOf(Date);
+    });
   });
+  describe("異常パターン", () => {
+    it("タイトルが未入力だとエラーになる", () => {
+      const data = {
+        id: 1,
+        title: "",
+        body: "ダミーボディ",
+      };
 
-  it("ボディが未入力だエラーになる", () => {
-    const data = {
-      id: 1,
-      title: "ダミータイトル",
-      body: "",
-    };
+      expect(() => {
+        new TodoEntity(data);
+      }).toThrow("titleの内容は必須です");
+    });
 
-    expect(() => {
-      new TodoEntity(data);
-    }).toThrow("bodyの内容は必須です");
-  });
+    it("ボディが未入力だエラーになる", () => {
+      const data = {
+        id: 1,
+        title: "ダミータイトル",
+        body: "",
+      };
 
-  it("タイトルとボディに入力内容(1文字以上)があればエラーは発生しない", () => {
-    const data = {
-      id: 1,
-      title: "ダミータイトル",
-      body: "ダミーボディ",
-    };
+      expect(() => {
+        new TodoEntity(data);
+      }).toThrow("bodyの内容は必須です");
+    });
 
-    const instance = new TodoEntity(data);
-    expect(instance.id).toEqual(1);
-    expect(instance.title).toEqual("ダミータイトル");
-    expect(instance.body).toEqual("ダミーボディ");
-    expect(instance.createdAt).toBeInstanceOf(Date);
-    expect(instance.updatedAt).toBeInstanceOf(Date);
+    it("タイトルが未入力だと、Todo情報の更新を中断する", () => {
+      const data = {
+        id: 1,
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+      };
+
+      const instance = new TodoEntity(data);
+      expect(() => {
+        instance.update({ title: "", body: "変更後のボディ" });
+      }).toThrow("更新処理を中断(titleの更新データがない為)");
+    });
+
+    it("ボディが未入力だと、Todo情報の更新を中断する", () => {
+      const data = {
+        id: 1,
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+      };
+
+      const instance = new TodoEntity(data);
+      expect(() => {
+        instance.update({ title: "変更後のタイトル", body: "" });
+      }).toThrow("更新処理を中断(bodyの更新データがない為)");
+    });
   });
 });

--- a/__test__/repositories/TodoRepository.spec.ts
+++ b/__test__/repositories/TodoRepository.spec.ts
@@ -31,18 +31,18 @@ describe("TodoRepository", () => {
         });
 
         expect(result1).toBeInstanceOf(TodoEntity);
-        expect(result1.id).toEqual(1);
-        expect(result1.title).toEqual("ダミータイトル1");
-        expect(result1.body).toEqual("ダミーボディ1");
-        expect(result1.createdAt).toBeInstanceOf(Date);
-        expect(result1.updatedAt).toBeInstanceOf(Date);
+        expect(result1.getTodoEntity.id).toEqual(1);
+        expect(result1.getTodoEntity.title).toEqual("ダミータイトル1");
+        expect(result1.getTodoEntity.body).toEqual("ダミーボディ1");
+        expect(result1.getTodoEntity.createdAt).toBeInstanceOf(Date);
+        expect(result1.getTodoEntity.updatedAt).toBeInstanceOf(Date);
 
         expect(result2).toBeInstanceOf(TodoEntity);
-        expect(result2.id).toEqual(2);
-        expect(result2.title).toEqual("ダミータイトル2");
-        expect(result2.body).toEqual("ダミーボディ2");
-        expect(result2.createdAt).toBeInstanceOf(Date);
-        expect(result2.updatedAt).toBeInstanceOf(Date);
+        expect(result2.getTodoEntity.id).toEqual(2);
+        expect(result2.getTodoEntity.title).toEqual("ダミータイトル2");
+        expect(result2.getTodoEntity.body).toEqual("ダミーボディ2");
+        expect(result2.getTodoEntity.createdAt).toBeInstanceOf(Date);
+        expect(result2.getTodoEntity.updatedAt).toBeInstanceOf(Date);
       });
 
       it("初期データの後にデータを追加し、そのデータ内容を一覧取得(listメソッド)する事できる。", () => {
@@ -77,41 +77,56 @@ describe("TodoRepository", () => {
 
         const result1: TodoEntity | null = instance.find(1);
 
-        expect(result1?.id).toEqual(1);
-        expect(result1?.title).toEqual("ダミータイトル1");
-        expect(result1?.body).toEqual("ダミーボディ1");
-        expect(result1?.createdAt).toBeInstanceOf(Date);
-        expect(result1?.updatedAt).toBeInstanceOf(Date);
+        expect(result1?.getTodoEntity.id).toEqual(1);
+        expect(result1?.getTodoEntity.title).toEqual("ダミータイトル1");
+        expect(result1?.getTodoEntity.body).toEqual("ダミーボディ1");
+        expect(result1?.getTodoEntity.createdAt).toBeInstanceOf(Date);
+        expect(result1?.getTodoEntity.updatedAt).toBeInstanceOf(Date);
 
         const result2: TodoEntity | null = instance.find(2);
 
-        expect(result2?.id).toEqual(2);
-        expect(result2?.title).toEqual("ダミータイトル2");
-        expect(result2?.body).toEqual("ダミーボディ2");
-        expect(result2?.createdAt).toBeInstanceOf(Date);
-        expect(result2?.updatedAt).toBeInstanceOf(Date);
-      });
-    });
-
-    it("updateメソッドを実行すると、DB内のデータを更新する事ができる。", () => {
-      const instance = new TodoRepository();
-      const dammyData = instance.save({
-        title: "ダミータイトル",
-        body: "ダミーボディ",
+        expect(result2?.getTodoEntity.id).toEqual(2);
+        expect(result2?.getTodoEntity.title).toEqual("ダミータイトル2");
+        expect(result2?.getTodoEntity.body).toEqual("ダミーボディ2");
+        expect(result2?.getTodoEntity.createdAt).toBeInstanceOf(Date);
+        expect(result2?.getTodoEntity.updatedAt).toBeInstanceOf(Date);
       });
 
-      const result = instance.update({
-        id: 1,
-        title: "変更後のタイトル",
-        body: "変更後のボディ",
+      it("updateメソッドを実行すると、DB内のデータを更新する事ができる。", () => {
+        const instance = new TodoRepository();
+        const dammyData = instance.save({
+          title: "ダミータイトル",
+          body: "ダミーボディ",
+        });
+        expect(
+          instance.update({
+            id: 1,
+            title: "変更後のタイトル",
+            body: "変更後のボディ",
+          })
+        ).toEqual({
+          id: 1,
+          title: "変更後のタイトル",
+          body: "変更後のボディ",
+          createdAt: dammyData.getTodoEntity.createdAt,
+          updatedAt: new Date(),
+        });
       });
 
-      expect(result).toEqual({
-        id: 1,
-        title: "変更後のタイトル",
-        body: "変更後のボディ",
-        createdAt: new Date(),
-        updatedAt: new Date(),
+      it("updateメソッドを実行した後は、updatedAtの方がcreatedAtよりも新しい時間になっている。", () => {
+        const instance = new TodoRepository();
+        instance.save({
+          title: "ダミータイトル",
+          body: "ダミーボディ",
+        });
+        const latestData = instance.update({
+          id: 1,
+          title: "変更後のタイトル",
+          body: "変更後のボディ",
+        });
+
+        expect(latestData.createdAt <= latestData.updatedAt).toBeTruthy();
+        expect(latestData.createdAt !== latestData.updatedAt).toBeTruthy();
       });
     });
   });
@@ -124,20 +139,16 @@ describe("TodoRepository", () => {
       expect(entity).toBeNull();
     });
 
-    it("更新時のタイトル or ボディが未入力だとエラーになる", () => {
-      const instance = new TodoRepository();
-      const dammyData = instance.save({
-        title: "ダミータイトル",
-        body: "ダミーボディ",
-      });
+    it("存在しないIDの値を更新しようとした場合、エラーオブジェクトが返る", () => {
+      const repository = new TodoRepository();
 
       expect(() => {
-        instance.update({ id: 1, title: "", body: "変更後のタイトル" });
-      }).toThrow("titleの内容は必須です");
-
-      expect(() => {
-        instance.update({ id: 1, title: "変更後のタイトル", body: "" });
-      }).toThrow("bodyの内容は必須です");
+        repository.update({
+          id: 999,
+          title: "ダミータイトル",
+          body: "ダミーボディ",
+        });
+      }).toThrow("idに該当するtodoが存在しません。");
     });
   });
 });

--- a/__test__/repositories/TodoRepository.spec.ts
+++ b/__test__/repositories/TodoRepository.spec.ts
@@ -92,6 +92,28 @@ describe("TodoRepository", () => {
         expect(result2?.updatedAt).toBeInstanceOf(Date);
       });
     });
+
+    it("updateメソッドを実行すると、DB内のデータを更新する事ができる。", () => {
+      const instance = new TodoRepository();
+      const dammyData = instance.save({
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+      });
+
+      const result = instance.update({
+        id: 1,
+        title: "変更後のタイトル",
+        body: "変更後のボディ",
+      });
+
+      expect(result).toEqual({
+        id: 1,
+        title: "変更後のタイトル",
+        body: "変更後のボディ",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    });
   });
 
   describe("異常パターン", () => {
@@ -100,6 +122,22 @@ describe("TodoRepository", () => {
       const entity = repository.find(999);
 
       expect(entity).toBeNull();
+    });
+
+    it("更新時のタイトル or ボディが未入力だとエラーになる", () => {
+      const instance = new TodoRepository();
+      const dammyData = instance.save({
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+      });
+
+      expect(() => {
+        instance.update({ id: 1, title: "", body: "変更後のタイトル" });
+      }).toThrow("titleの内容は必須です");
+
+      expect(() => {
+        instance.update({ id: 1, title: "変更後のタイトル", body: "" });
+      }).toThrow("bodyの内容は必須です");
     });
   });
 });

--- a/__test__/repositories/TodoRepository.spec.ts
+++ b/__test__/repositories/TodoRepository.spec.ts
@@ -98,18 +98,18 @@ describe("TodoRepository", () => {
           title: "ダミータイトル",
           body: "ダミーボディ",
         });
-        expect(
-          instance.update({
-            id: 1,
-            title: "変更後のタイトル",
-            body: "変更後のボディ",
-          })
-        ).toEqual({
+        const result = instance.update({
+          id: 1,
+          title: "変更後のタイトル",
+          body: "変更後のボディ",
+        });
+
+        expect(result).toEqual({
           id: 1,
           title: "変更後のタイトル",
           body: "変更後のボディ",
           createdAt: dammyData.getTodoEntity.createdAt,
-          updatedAt: new Date(),
+          updatedAt: result.updatedAt,
         });
       });
 

--- a/controllers/todos/GetTodoController.ts
+++ b/controllers/todos/GetTodoController.ts
@@ -22,6 +22,7 @@ export class GetTodoController {
       res.status(404).json(errorObj);
       return;
     }
-    return res.status(200).json(todoItem);
+    const responseData = todoItem.getTodoEntity;
+    return res.status(200).json(responseData);
   }
 }

--- a/controllers/todos/GetTodosController.ts
+++ b/controllers/todos/GetTodosController.ts
@@ -10,7 +10,8 @@ export class GetTodosController {
 
   list(req: Request, res: Response) {
     const todos = this.repository.list();
+    const responseData = todos.map((todo) => todo.getTodoEntity);
 
-    return res.status(200).json(todos);
+    return res.status(200).json(responseData);
   }
 }

--- a/entities/Todo.ts
+++ b/entities/Todo.ts
@@ -8,11 +8,11 @@ export interface TodoEntityInput extends TodoInput {
 }
 
 export class TodoEntity {
-  public readonly id: number;
-  public readonly title: string;
-  public readonly body: string;
-  public readonly createdAt: Date;
-  public readonly updatedAt: Date;
+  public id: number;
+  public title: string;
+  public body: string;
+  public createdAt: Date;
+  public updatedAt: Date;
 
   constructor({ id, title, body }: TodoEntityInput) {
     if (!title) {

--- a/entities/Todo.ts
+++ b/entities/Todo.ts
@@ -42,11 +42,8 @@ export class TodoEntity {
   }
 
   update({ title, body }: TodoInput) {
-    if (!title) {
-      throw new Error("更新処理を中断(titleの更新データがない為)");
-    }
-    if (!body) {
-      throw new Error("更新処理を中断(bodyの更新データがない為)");
+    if (!title || !body) {
+      throw new Error("更新処理を中断(更新データがない為)");
     }
 
     this.title = title ?? this.title;

--- a/entities/Todo.ts
+++ b/entities/Todo.ts
@@ -5,16 +5,18 @@ export interface TodoInput {
 
 export interface TodoEntityInput extends TodoInput {
   id: number;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
 
 export class TodoEntity {
-  public id: number;
-  public title: string;
-  public body: string;
-  public createdAt: Date;
-  public updatedAt: Date;
+  private id: number;
+  private title: string;
+  private body: string;
+  private createdAt: Date;
+  private updatedAt: Date;
 
-  constructor({ id, title, body }: TodoEntityInput) {
+  constructor({ id, title, body, createdAt, updatedAt }: TodoEntityInput) {
     if (!title) {
       throw new Error("titleの内容は必須です");
     }
@@ -25,7 +27,40 @@ export class TodoEntity {
     this.id = id;
     this.title = title;
     this.body = body;
-    this.createdAt = new Date();
+    this.createdAt = createdAt ?? new Date();
+    this.updatedAt = updatedAt ?? new Date();
+  }
+
+  clone() {
+    return new TodoEntity({
+      id: this.id,
+      title: this.title,
+      body: this.body,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    });
+  }
+
+  update({ title, body }: TodoInput) {
+    if (!title) {
+      throw new Error("更新処理を中断(titleの更新データがない為)");
+    }
+    if (!body) {
+      throw new Error("更新処理を中断(bodyの更新データがない為)");
+    }
+
+    this.title = title ?? this.title;
+    this.body = body ?? this.body;
     this.updatedAt = new Date();
+  }
+
+  public get getTodoEntity() {
+    return {
+      id: this.id,
+      title: this.title,
+      body: this.body,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
   }
 }

--- a/repositories/TodoRepository.ts
+++ b/repositories/TodoRepository.ts
@@ -1,4 +1,4 @@
-import type { TodoInput } from "../entities/Todo";
+import type { TodoEntityInput, TodoInput } from "../entities/Todo";
 import { TodoEntity } from "../entities/Todo";
 
 export class TodoRepository {
@@ -36,6 +36,28 @@ export class TodoRepository {
     if (!todo) {
       return null;
     }
+    return todo;
+  }
+
+  update({ id, title, body }: TodoEntityInput) {
+    if (!id) {
+      throw new Error("idは必須です");
+    }
+    if (!title) {
+      throw new Error("titleの内容は必須です");
+    }
+    if (!body) {
+      throw new Error("bodyの内容は必須です");
+    }
+    const todo = this.db.find((e) => e.id === id);
+    if (!todo) {
+      throw new Error("idに該当するtodoが存在しません。");
+    }
+
+    todo.title = title;
+    todo.body = body;
+    todo.updatedAt = new Date();
+
     return todo;
   }
 }

--- a/repositories/TodoRepository.ts
+++ b/repositories/TodoRepository.ts
@@ -28,36 +28,26 @@ export class TodoRepository {
   }
 
   list() {
-    return this.db.slice();
+    const todos = this.db.map((todo) => todo.clone());
+    return todos;
   }
 
   find(id: number) {
-    const todo = this.db.find((e) => e.id === id);
+    const todo = this.db.find((e) => e.getTodoEntity.id === id);
     if (!todo) {
       return null;
     }
-    return todo;
+    return todo.clone();
   }
 
   update({ id, title, body }: TodoEntityInput) {
-    if (!id) {
-      throw new Error("idは必須です");
-    }
-    if (!title) {
-      throw new Error("titleの内容は必須です");
-    }
-    if (!body) {
-      throw new Error("bodyの内容は必須です");
-    }
-    const todo = this.db.find((e) => e.id === id);
+    const todo = this.db.find((e) => e.getTodoEntity.id === id);
     if (!todo) {
       throw new Error("idに該当するtodoが存在しません。");
     }
 
-    todo.title = title;
-    todo.body = body;
-    todo.updatedAt = new Date();
-
-    return todo;
+    todo.update({ title, body });
+    const entityData = todo.clone();
+    return entityData.getTodoEntity;
   }
 }


### PR DESCRIPTION
コードレビューの方、よろしくお願いします。

TodoRepository内にTodoを更新する為の機能を追加しました。

テストファイルでは、仮のデータをsaveメソッドで新規作成した後に、
そのTodoデータにupdateメソッドを実行し、result変数に格納した値が
期待値に合致するか否かを対象としました。

異常パターンのテストは、今回はTodo.ts作成時の
パターンで出来ると思い、入力情報の不足にエラーオブジェクトが
投げれているかをチェックする実装を加えました。

IDに対するテストは行っていません。
これに対しては、コントローラーとルーター作成後の作業かなと
思い、コチラに関して必要かどうかを教えて頂けますでしょうか。



