### PR TITLE
【追加機能の実装】listメソッドの一覧取得を範囲指定する

### DIFF
--- a/__test__/repositories/TodoRepository.spec.ts
+++ b/__test__/repositories/TodoRepository.spec.ts
@@ -45,21 +45,71 @@ describe("TodoRepository", () => {
         expect(result2.getTodoEntity.updatedAt).toBeInstanceOf(Date);
       });
 
-      it("初期データの後にデータを追加し、そのデータ内容を一覧取得(listメソッド)する事できる。", () => {
-        const instance = new TodoRepository([
-          { title: "ダミータイトル1", body: "ダミーボディ1" },
-          { title: "ダミータイトル2", body: "ダミーボディ2" },
-        ]);
-
-        const result = instance.save({
-          title: "ダミータイトル3",
-          body: "ダミーボディ3",
-        });
-
+      it("listメソッドを実行時、パラメーターの指定がない場合は、先頭から10件のデータを取得する", () => {
+        const instance = new TodoRepository();
+        for (let i = 1; i <= 21; i++) {
+          instance.save({
+            title: `ダミータイトル${i}`,
+            body: `ダミーボディ${i}`,
+          });
+        }
         const list = instance.list();
 
+        expect(list.length).toEqual(10);
+        expect(list.map((e) => e.getTodoEntity.id)).toEqual([
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        ]);
+        expect(list[0].getTodoEntity.title).toEqual("ダミータイトル1");
+        expect(list[0].getTodoEntity.body).toEqual("ダミーボディ1");
+      });
+
+      it("listメソッドを実行時、パラメーターの指定(page=2)をした場合、11件目のデータから20件のデータを取得する", () => {
+        const instance = new TodoRepository();
+        for (let i = 1; i <= 21; i++) {
+          instance.save({
+            title: `ダミータイトル${i}`,
+            body: `ダミーボディ${i}`,
+          });
+        }
+        const list = instance.list({ page: 2 });
+
+        expect(list.length).toEqual(10);
+        expect(list.map((e) => e.getTodoEntity.id)).toEqual([
+          11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        ]);
+        expect(list[0].getTodoEntity.title).toEqual("ダミータイトル11");
+        expect(list[0].getTodoEntity.body).toEqual("ダミーボディ11");
+      });
+
+      it("listメソッドを実行時、パラメーターの指定(count=5)をした場合、先頭から5件のデータを取得する", () => {
+        const instance = new TodoRepository();
+        for (let i = 1; i <= 11; i++) {
+          instance.save({
+            title: `ダミータイトル${i}`,
+            body: `ダミーボディ${i}`,
+          });
+        }
+        const list = instance.list({ count: 5 });
+
+        expect(list.length).toEqual(5);
+        expect(list.map((e) => e.getTodoEntity.id)).toEqual([1, 2, 3, 4, 5]);
+        expect(list[4].getTodoEntity.title).toEqual("ダミータイトル5");
+        expect(list[4].getTodoEntity.body).toEqual("ダミーボディ5");
+      });
+
+      it("listメソッドを実行時、パラメーターの指定(page=2,count=3)をした場合、4件目のデータから3件のデータを取得する", () => {
+        const instance = new TodoRepository();
+        for (let i = 1; i <= 11; i++) {
+          instance.save({
+            title: `ダミータイトル${i}`,
+            body: `ダミーボディ${i}`,
+          });
+        }
+        const list = instance.list({ page: 2, count: 3 });
         expect(list.length).toEqual(3);
-        expect(result).toEqual(list[2]);
+        expect(list.map((e) => e.getTodoEntity.id)).toEqual([4, 5, 6]);
+        expect(list[0].getTodoEntity.title).toEqual("ダミータイトル4");
+        expect(list[0].getTodoEntity.body).toEqual("ダミーボディ4");
       });
 
       it("findメソッドを実行すると、DBに保持されているデータから、一件の値を取得する事ができる", () => {
@@ -128,26 +178,25 @@ describe("TodoRepository", () => {
         expect(latestData.createdAt <= latestData.updatedAt).toBeTruthy();
         expect(latestData.createdAt !== latestData.updatedAt).toBeTruthy();
       });
-    });
 
-    it("deleteメソッドを実行すると、DB内の指定した(ID)データを削除する事ができる。", () => {
-      const instance = new TodoRepository([
-        { title: "ダミータイトル1", body: "ダミーボディ1" },
-        { title: "ダミータイトル2", body: "ダミーボディ2" },
-      ]);
-      const dbOldData = instance.list();
-      instance.delete(1);
-      const dbCurrentData = instance.list();
+      it("deleteメソッドを実行すると、DB内の指定した(ID)データを削除する事ができる。", () => {
+        const instance = new TodoRepository([
+          { title: "ダミータイトル1", body: "ダミーボディ1" },
+          { title: "ダミータイトル2", body: "ダミーボディ2" },
+        ]);
+        const dbOldData = instance.list();
+        instance.delete(1);
+        const dbCurrentData = instance.list({ page: 1, count: 10 });
 
-      expect(dbOldData[0].getTodoEntity.id).toEqual(1);
-      expect(dbOldData[1].getTodoEntity.id).toEqual(2);
+        expect(dbOldData[0].getTodoEntity.id).toEqual(1);
+        expect(dbOldData[1].getTodoEntity.id).toEqual(2);
 
-      expect(dbCurrentData[0].getTodoEntity.id).toEqual(2);
-      expect(dbOldData.length).toEqual(2);
-      expect(dbCurrentData.length).toEqual(1);
+        expect(dbCurrentData[0].getTodoEntity.id).toEqual(2);
+        expect(dbOldData.length).toEqual(2);
+        expect(dbCurrentData.length).toEqual(1);
+      });
     });
   });
-
   describe("異常パターン", () => {
     it("不正なIDを指定した場合(findメソッド実行時)、エラーオブジェクトが返る", () => {
       const repository = new TodoRepository();

--- a/repositories/TodoRepository.ts
+++ b/repositories/TodoRepository.ts
@@ -1,6 +1,9 @@
 import type { TodoEntityInput, TodoInput } from "../entities/Todo";
 import { TodoEntity } from "../entities/Todo";
 
+const DEFAULT_PAGE = 1;
+const DEFAULT_COUNT = 10;
+
 export class TodoRepository {
   private nextId = 1;
   private db: TodoEntity[] = [];
@@ -27,9 +30,24 @@ export class TodoRepository {
     return inputData;
   }
 
-  list() {
-    const todos = this.db.map((todo) => todo.clone());
-    return todos;
+  list(
+    { page = DEFAULT_PAGE, count = DEFAULT_COUNT } = {
+      page: DEFAULT_PAGE,
+      count: DEFAULT_COUNT,
+    }
+  ) {
+    if (page < 1 || !Number.isInteger(page)) {
+      throw new Error("pageは1以上の整数のみ");
+    }
+    if (count < 1 || !Number.isInteger(count)) {
+      throw new Error("countは1以上の整数のみ");
+    }
+
+    const offset = (page - 1) * count;
+    const scopedTodos = this.db.slice(offset, offset + count);
+    const clonedTodos = scopedTodos.map((todo) => todo.clone());
+
+    return clonedTodos;
   }
 
   find(id: number) {


### PR DESCRIPTION
コードレビューの方、よろしくお願いします。

今回は既存機能への追加実装でしたが、
ブランチにtodos-model(todo-modelは既存ブランチ)が
なかったので、新しいブランチで実装を行いました。


前田さんのサンプルコード

{ page = DEFAULT_PAGE, limit = DEFAULT_COUNT } = {
      page: DEFAULT_PAGE,
      limit: DEFAULT_COUNT,
    }

実装初め、
これがTSの型だと思い、
typeで型を作って実装を行いました。

listメソッドを使用している他ファイルに
パラメータを要求され、前田さんがこのような複数ファイルの
修正を余儀なくするような実装はさせないだろうと思い、上記問題に気が
つきました。

デフォルトで値を指定する場合、？を使う方法は
わかりますが、上記の指定方法は処理の流れがわかりません。


現在の認識ですが、
 = の右辺は、デフォルト値をセットしている。
引数で page:1などで指定をすると、
その受けとった値(page: DEFAULT_PAGE→page:1)を左辺に
代入していると認識です。


この指定の仕方だと、
・listメソッドに引数がなくても良い
・引数がない場合はデフォルト値がセットされる
についてご指導お願いできますでしょうか。

