### PR TITLE
【DeleteTodoController.spec.tsのテストファイル修正】～DBに依存したintegration test～

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "migrate:postgres": "dotenv -e .env.test -- npx prisma migrate dev --name postgres-init",
     "start": "nodemon src/index.ts",
-    "test": "dotenv -e .env.test -- jest"
+    "test": "dotenv -e .env.test -- jest --runInBand"
   },
   "author": "",
   "license": "ISC",

--- a/src/__test__/app/api/todos/DeleteTodoController.spec.ts
+++ b/src/__test__/app/api/todos/DeleteTodoController.spec.ts
@@ -1,5 +1,4 @@
 import { requestAPI } from "../../../helper/requestHelper";
-import { TodoResponseType } from "../../../helper/types/TodoResponseType";
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
@@ -17,34 +16,21 @@ describe("[APIテスト] Todo一件の削除", () => {
       }
     });
     it("deleteメソッド実行前、DBに格納されているTodoは3件である。", async () => {
-      const response = await requestAPI({
-        method: "get",
-        endPoint: "/api/todos",
-        statusCode: 200,
-      });
-
-      const todoItems: TodoResponseType[] = response.body;
-      const dbOldData = todoItems;
+      const dbOldData = await prisma.todo.findMany({});
 
       expect(dbOldData.length).toEqual(3);
     });
     it("id:1のデータ削除", async () => {
-      await requestAPI({
+      const response = await requestAPI({
         method: "delete",
         endPoint: "/api/todos/1",
         statusCode: 200,
       });
+      const { id, title, body } = response.body;
 
-      const response = await requestAPI({
-        method: "get",
-        endPoint: "/api/todos",
-        statusCode: 200,
-      });
-
-      const notFirstIdTodos: TodoResponseType[] = response.body;
-      const actualIds = notFirstIdTodos.map((todo) => todo.id);
-
-      expect(actualIds).toEqual([2, 3]);
+      expect(id).toEqual(1);
+      expect(title).toEqual("ダミータイトル1");
+      expect(body).toEqual("ダミーボディ1");
     });
     it("deleteメソッド実行後、3件のTodoから1件のデータが削除されている。", async () => {
       await requestAPI({
@@ -53,13 +39,7 @@ describe("[APIテスト] Todo一件の削除", () => {
         statusCode: 200,
       });
 
-      const response = await requestAPI({
-        method: "get",
-        endPoint: "/api/todos",
-        statusCode: 200,
-      });
-      const notFirstIdTodos: TodoResponseType[] = response.body;
-      const dbCurrentData = notFirstIdTodos;
+      const dbCurrentData = await prisma.todo.findMany({});
 
       expect(dbCurrentData.length).toEqual(2);
     });

--- a/src/__test__/app/api/todos/GetTodoController.spec.ts
+++ b/src/__test__/app/api/todos/GetTodoController.spec.ts
@@ -5,14 +5,17 @@ const prisma = new PrismaClient();
 
 describe("[APIテスト] Todo1件の取得", () => {
   describe("成功パターン", () => {
+    beforeEach(async () => {
+      for (let i = 1; i <= 2; i++) {
+        await prisma.todo.create({
+          data: {
+            title: "ダミータイトル" + i,
+            body: "ダミーボディ" + i,
+          },
+        });
+      }
+    });
     it("id:1のデータ取得", async () => {
-      await prisma.todo.create({
-        data: {
-          title: "ダミータイトル1",
-          body: "ダミーボディ1",
-        },
-      });
-
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos/1",
@@ -26,15 +29,6 @@ describe("[APIテスト] Todo1件の取得", () => {
       expect(body).toEqual("ダミーボディ1");
     });
     it("id:2のデータ取得", async () => {
-      for (let i = 1; i <= 2; i++) {
-        await prisma.todo.create({
-          data: {
-            title: "ダミータイトル" + i,
-            body: "ダミーボディ" + i,
-          },
-        });
-      }
-
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos/2",
@@ -48,20 +42,20 @@ describe("[APIテスト] Todo1件の取得", () => {
       expect(body).toEqual("ダミーボディ2");
     });
   });
-  describe("異常パターン", () => {
-    it("存在しないIDへのリクエストはエラーになる", async () => {
-      const response = await requestAPI({
-        method: "get",
-        endPoint: "/api/todos/999",
-        statusCode: 404,
-      });
-
-      const { code, message, stat } = response.body;
-
-      expect(response.statusCode).toEqual(404);
-      expect(code).toEqual(404);
-      expect(message).toEqual("Not found");
-      expect(stat).toEqual("fail");
+});
+describe("異常パターン", () => {
+  it("存在しないIDへのリクエストはエラーになる", async () => {
+    const response = await requestAPI({
+      method: "get",
+      endPoint: "/api/todos/999",
+      statusCode: 404,
     });
+
+    const { code, message, stat } = response.body;
+
+    expect(response.statusCode).toEqual(404);
+    expect(code).toEqual(404);
+    expect(message).toEqual("Not found");
+    expect(stat).toEqual("fail");
   });
 });

--- a/src/__test__/app/api/todos/GetTodoController.spec.ts
+++ b/src/__test__/app/api/todos/GetTodoController.spec.ts
@@ -1,18 +1,17 @@
 import { requestAPI } from "../../../helper/requestHelper";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
 
 describe("[APIテスト] Todo1件の取得", () => {
   describe("成功パターン", () => {
     it("id:1のデータ取得", async () => {
-      const requestFirstData = {
-        title: "ダミータイトル1",
-        body: "ダミーボディ1",
-      };
-
-      await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/",
-        statusCode: 200,
-      }).send(requestFirstData);
+      await prisma.todo.create({
+        data: {
+          title: "ダミータイトル1",
+          body: "ダミーボディ1",
+        },
+      });
 
       const response = await requestAPI({
         method: "get",
@@ -28,17 +27,14 @@ describe("[APIテスト] Todo1件の取得", () => {
     });
     it("id:2のデータ取得", async () => {
       for (let i = 1; i <= 2; i++) {
-        const requestSecondData = {
-          title: `ダミータイトル${i}`,
-          body: `ダミーボディ${i}`,
-        };
-
-        await requestAPI({
-          method: "post",
-          endPoint: "/api/todos/",
-          statusCode: 200,
-        }).send(requestSecondData);
+        await prisma.todo.create({
+          data: {
+            title: "ダミータイトル" + i,
+            body: "ダミーボディ" + i,
+          },
+        });
       }
+
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos/2",

--- a/src/__test__/app/api/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/app/api/todos/UpdateTodoController.spec.ts
@@ -6,7 +6,7 @@ const prisma = new PrismaClient();
 describe("[APIテスト] Todo一件の更新", () => {
   describe("成功パターン", () => {
     beforeEach(async () => {
-      for (let i = 1; i <= 3; i++) {
+      for (let i = 1; i <= 2; i++) {
         await prisma.todo.create({
           data: {
             title: "ダミータイトル" + i,

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -1,5 +1,8 @@
 import { TodoRepository } from "../../repositories/TodoRepository";
 import type { Todo } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
 
 describe("TodoRepository", () => {
   describe("成功パターン", () => {
@@ -40,9 +43,11 @@ describe("TodoRepository", () => {
         const repository = new TodoRepository();
 
         for (let i = 1; i <= 11; i++) {
-          await repository.save({
-            title: `ダミータイトル${i}`,
-            body: `ダミーボディ${i}`,
+          await prisma.todo.create({
+            data: {
+              title: "ダミータイトル" + i,
+              body: "ダミーボディ" + i,
+            },
           });
         }
 
@@ -57,9 +62,11 @@ describe("TodoRepository", () => {
         const repository = new TodoRepository();
 
         for (let i = 1; i <= 21; i++) {
-          await repository.save({
-            title: `ダミータイトル${i}`,
-            body: `ダミーボディ${i}`,
+          await prisma.todo.create({
+            data: {
+              title: "ダミータイトル" + i,
+              body: "ダミーボディ" + i,
+            },
           });
         }
 
@@ -74,11 +81,14 @@ describe("TodoRepository", () => {
         const repository = new TodoRepository();
 
         for (let i = 1; i <= 11; i++) {
-          await repository.save({
-            title: `ダミータイトル${i}`,
-            body: `ダミーボディ${i}`,
+          await prisma.todo.create({
+            data: {
+              title: "ダミータイトル" + i,
+              body: "ダミーボディ" + i,
+            },
           });
         }
+
         const listDataResult = await repository.list({ count: 5 });
 
         expect(listDataResult.length).toEqual(5);
@@ -90,11 +100,14 @@ describe("TodoRepository", () => {
         const repository = new TodoRepository();
 
         for (let i = 1; i <= 11; i++) {
-          await repository.save({
-            title: `ダミータイトル${i}`,
-            body: `ダミーボディ${i}`,
+          await prisma.todo.create({
+            data: {
+              title: "ダミータイトル" + i,
+              body: "ダミーボディ" + i,
+            },
           });
         }
+
         const listDataResult = await repository.list({ page: 2, count: 3 });
 
         expect(listDataResult.length).toEqual(3);
@@ -105,10 +118,12 @@ describe("TodoRepository", () => {
       it("findメソッドを実行すると、DBに保持されているデータから、一件の値を取得する事ができる", async () => {
         const repository = new TodoRepository();
 
-        for (let i = 1; i <= 3; i++) {
-          await repository.save({
-            title: `ダミータイトル${i}`,
-            body: `ダミーボディ${i}`,
+        for (let i = 1; i <= 2; i++) {
+          await prisma.todo.create({
+            data: {
+              title: "ダミータイトル" + i,
+              body: "ダミーボディ" + i,
+            },
           });
         }
 
@@ -130,10 +145,12 @@ describe("TodoRepository", () => {
       it("updateメソッドを実行すると、DB内のデータを更新する事ができる。", async () => {
         const repository = new TodoRepository();
 
-        for (let i = 1; i <= 3; i++) {
-          await repository.save({
-            title: `ダミータイトル${i}`,
-            body: `ダミーボディ${i}`,
+        for (let i = 1; i <= 2; i++) {
+          await prisma.todo.create({
+            data: {
+              title: "ダミータイトル" + i,
+              body: "ダミーボディ" + i,
+            },
           });
         }
 
@@ -154,10 +171,12 @@ describe("TodoRepository", () => {
       it("updateメソッドを実行した後は、updatedAtの方がcreatedAtよりも新しい時間になっている。", async () => {
         const repository = new TodoRepository();
 
-        for (let i = 1; i <= 3; i++) {
-          await repository.save({
-            title: `ダミータイトル${i}`,
-            body: `ダミーボディ${i}`,
+        for (let i = 1; i <= 2; i++) {
+          await prisma.todo.create({
+            data: {
+              title: "ダミータイトル" + i,
+              body: "ダミーボディ" + i,
+            },
           });
         }
 
@@ -172,21 +191,23 @@ describe("TodoRepository", () => {
       it("deleteメソッドを実行すると、DB内の指定した(ID)データを削除する事ができる。", async () => {
         const repository = new TodoRepository();
 
-        for (let i = 1; i <= 3; i++) {
-          await repository.save({
-            title: `ダミータイトル${i}`,
-            body: `ダミーボディ${i}`,
+        for (let i = 1; i <= 2; i++) {
+          await prisma.todo.create({
+            data: {
+              title: "ダミータイトル" + i,
+              body: "ダミーボディ" + i,
+            },
           });
         }
         const dbOldData = await repository.list();
         await repository.delete(1);
         const dbCurrentData = await repository.list();
 
-        expect(dbOldData.length).toEqual(3);
+        expect(dbOldData.length).toEqual(2);
         expect(dbOldData[0].id).toEqual(1);
         expect(dbOldData[1].id).toEqual(2);
 
-        expect(dbCurrentData.length).toEqual(2);
+        expect(dbCurrentData.length).toEqual(1);
         expect(dbCurrentData[0].id).toEqual(2);
       });
     });

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -125,24 +125,27 @@ describe("TodoRepository", () => {
       it("updateメソッドを実行した後は、updatedAtの方がcreatedAtよりも新しい時間になっている。", async () => {
         const repository = new TodoRepository();
 
-        const latestDate = await repository.update({
+        const latestDateResult = await repository.update({
           id: 1,
           title: "変更後のタイトル",
           body: "変更後のボディ",
         });
 
-        expect(latestDate.createdAt < latestDate.updatedAt).toBeTruthy();
+        expect(
+          latestDateResult.createdAt < latestDateResult.updatedAt
+        ).toBeTruthy();
       });
       it("deleteメソッドを実行すると、DB内の指定した(ID)データを削除する事ができる。", async () => {
         const repository = new TodoRepository();
 
-        const dbOldData = await repository.list();
-        await repository.delete(1);
-        const dbCurrentData = await repository.list();
+        const dbOldDataResult = await repository.list();
+        const deletedDataResult = await repository.delete(1);
+        const dbCurrentDataResult = await repository.list();
 
-        const oldDataId = dbOldData.map((todo) => todo.id);
-        const currentDataId = dbCurrentData.map((todo) => todo.id);
+        const oldDataId = dbOldDataResult.map((todo) => todo.id);
+        const currentDataId = dbCurrentDataResult.map((todo) => todo.id);
 
+        expect(deletedDataResult.id).toEqual(1);
         expect(oldDataId).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         expect(currentDataId).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
       });

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -13,7 +13,7 @@ describe("TodoRepository", () => {
         expect(repository).toBeInstanceOf(TodoRepository);
       });
     });
-    describe("メソッドのテスト", () => {
+    describe("saveメソッドのテスト", () => {
       it("saveメソッドを実行すると、DBに値を保持し、その値に重複しないIDが付与される", async () => {
         const repository = new TodoRepository();
 
@@ -39,10 +39,10 @@ describe("TodoRepository", () => {
         expect(secondDataResult.createdAt).toBeInstanceOf(Date);
         expect(secondDataResult.updatedAt).toBeInstanceOf(Date);
       });
-      it("listメソッドを実行時、パラメーターの指定がない場合は、先頭から10件のデータを取得する", async () => {
-        const repository = new TodoRepository();
-
-        for (let i = 1; i <= 11; i++) {
+    });
+    describe("list・update・deleteメソッドのテスト", () => {
+      beforeEach(async () => {
+        for (let i = 1; i <= 21; i++) {
           await prisma.todo.create({
             data: {
               title: "ダミータイトル" + i,
@@ -50,7 +50,9 @@ describe("TodoRepository", () => {
             },
           });
         }
-
+      });
+      it("listメソッドを実行時、パラメーターの指定がない場合は、先頭から10件のデータを取得する", async () => {
+        const repository = new TodoRepository();
         const listDataResult = await repository.list();
 
         expect(listDataResult.length).toEqual(10);
@@ -60,16 +62,6 @@ describe("TodoRepository", () => {
       });
       it("listメソッドを実行時、パラメーターの指定(page=2)をした場合、11件目のデータから20件のデータを取得する", async () => {
         const repository = new TodoRepository();
-
-        for (let i = 1; i <= 21; i++) {
-          await prisma.todo.create({
-            data: {
-              title: "ダミータイトル" + i,
-              body: "ダミーボディ" + i,
-            },
-          });
-        }
-
         const listDataResult = await repository.list({ page: 2 });
 
         expect(listDataResult.length).toEqual(10);
@@ -79,16 +71,6 @@ describe("TodoRepository", () => {
       });
       it("listメソッドを実行時、パラメーターの指定(count=5)をした場合、先頭から5件のデータを取得する", async () => {
         const repository = new TodoRepository();
-
-        for (let i = 1; i <= 11; i++) {
-          await prisma.todo.create({
-            data: {
-              title: "ダミータイトル" + i,
-              body: "ダミーボディ" + i,
-            },
-          });
-        }
-
         const listDataResult = await repository.list({ count: 5 });
 
         expect(listDataResult.length).toEqual(5);
@@ -98,16 +80,6 @@ describe("TodoRepository", () => {
       });
       it("listメソッドを実行時、パラメーターの指定(page=2,count=3)をした場合、4件目のデータから3件のデータを取得する", async () => {
         const repository = new TodoRepository();
-
-        for (let i = 1; i <= 11; i++) {
-          await prisma.todo.create({
-            data: {
-              title: "ダミータイトル" + i,
-              body: "ダミーボディ" + i,
-            },
-          });
-        }
-
         const listDataResult = await repository.list({ page: 2, count: 3 });
 
         expect(listDataResult.length).toEqual(3);
@@ -117,15 +89,6 @@ describe("TodoRepository", () => {
       });
       it("findメソッドを実行すると、DBに保持されているデータから、一件の値を取得する事ができる", async () => {
         const repository = new TodoRepository();
-
-        for (let i = 1; i <= 2; i++) {
-          await prisma.todo.create({
-            data: {
-              title: "ダミータイトル" + i,
-              body: "ダミーボディ" + i,
-            },
-          });
-        }
 
         const initialDataResult = await repository.find(1);
         const secondDataResult = await repository.find(2);
@@ -145,15 +108,6 @@ describe("TodoRepository", () => {
       it("updateメソッドを実行すると、DB内のデータを更新する事ができる。", async () => {
         const repository = new TodoRepository();
 
-        for (let i = 1; i <= 2; i++) {
-          await prisma.todo.create({
-            data: {
-              title: "ダミータイトル" + i,
-              body: "ダミーボディ" + i,
-            },
-          });
-        }
-
         const latestResult: Todo = await repository.update({
           id: 1,
           title: "変更後のタイトル",
@@ -171,15 +125,6 @@ describe("TodoRepository", () => {
       it("updateメソッドを実行した後は、updatedAtの方がcreatedAtよりも新しい時間になっている。", async () => {
         const repository = new TodoRepository();
 
-        for (let i = 1; i <= 2; i++) {
-          await prisma.todo.create({
-            data: {
-              title: "ダミータイトル" + i,
-              body: "ダミーボディ" + i,
-            },
-          });
-        }
-
         const latestDate = await repository.update({
           id: 1,
           title: "変更後のタイトル",
@@ -191,24 +136,15 @@ describe("TodoRepository", () => {
       it("deleteメソッドを実行すると、DB内の指定した(ID)データを削除する事ができる。", async () => {
         const repository = new TodoRepository();
 
-        for (let i = 1; i <= 2; i++) {
-          await prisma.todo.create({
-            data: {
-              title: "ダミータイトル" + i,
-              body: "ダミーボディ" + i,
-            },
-          });
-        }
         const dbOldData = await repository.list();
         await repository.delete(1);
         const dbCurrentData = await repository.list();
 
-        expect(dbOldData.length).toEqual(2);
-        expect(dbOldData[0].id).toEqual(1);
-        expect(dbOldData[1].id).toEqual(2);
+        const oldDataId = dbOldData.map((todo) => todo.id);
+        const currentDataId = dbCurrentData.map((todo) => todo.id);
 
-        expect(dbCurrentData.length).toEqual(1);
-        expect(dbCurrentData[0].id).toEqual(2);
+        expect(oldDataId).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        expect(currentDataId).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
       });
     });
   });

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -17,27 +17,27 @@ describe("TodoRepository", () => {
       it("saveメソッドを実行すると、DBに値を保持し、その値に重複しないIDが付与される", async () => {
         const repository = new TodoRepository();
 
-        const initialDataResult: Todo = await repository.save({
+        const initialTodo: Todo = await repository.save({
           title: "ダミータイトル1",
           body: "ダミーボディ1",
         });
 
-        const secondDataResult: Todo = await repository.save({
+        const secondTodo: Todo = await repository.save({
           title: "ダミータイトル2",
           body: "ダミーボディ2",
         });
 
-        expect(initialDataResult.id).toEqual(1);
-        expect(initialDataResult.title).toEqual("ダミータイトル1");
-        expect(initialDataResult.body).toEqual("ダミーボディ1");
-        expect(initialDataResult.createdAt).toBeInstanceOf(Date);
-        expect(initialDataResult.updatedAt).toBeInstanceOf(Date);
+        expect(initialTodo.id).toEqual(1);
+        expect(initialTodo.title).toEqual("ダミータイトル1");
+        expect(initialTodo.body).toEqual("ダミーボディ1");
+        expect(initialTodo.createdAt).toBeInstanceOf(Date);
+        expect(initialTodo.updatedAt).toBeInstanceOf(Date);
 
-        expect(secondDataResult.id).toEqual(2);
-        expect(secondDataResult.title).toEqual("ダミータイトル2");
-        expect(secondDataResult.body).toEqual("ダミーボディ2");
-        expect(secondDataResult.createdAt).toBeInstanceOf(Date);
-        expect(secondDataResult.updatedAt).toBeInstanceOf(Date);
+        expect(secondTodo.id).toEqual(2);
+        expect(secondTodo.title).toEqual("ダミータイトル2");
+        expect(secondTodo.body).toEqual("ダミーボディ2");
+        expect(secondTodo.createdAt).toBeInstanceOf(Date);
+        expect(secondTodo.updatedAt).toBeInstanceOf(Date);
       });
     });
     describe("list・update・deleteメソッドのテスト", () => {
@@ -53,101 +53,99 @@ describe("TodoRepository", () => {
       });
       it("listメソッドを実行時、パラメーターの指定がない場合は、先頭から10件のデータを取得する", async () => {
         const repository = new TodoRepository();
-        const listDataResult = await repository.list();
+        const todoList = await repository.list();
 
-        expect(listDataResult.length).toEqual(10);
-        expect(listDataResult[2].id).toEqual(3);
-        expect(listDataResult[2].title).toEqual("ダミータイトル3");
-        expect(listDataResult[2].body).toEqual("ダミーボディ3");
+        expect(todoList.length).toEqual(10);
+        expect(todoList[2].id).toEqual(3);
+        expect(todoList[2].title).toEqual("ダミータイトル3");
+        expect(todoList[2].body).toEqual("ダミーボディ3");
       });
       it("listメソッドを実行時、パラメーターの指定(page=2)をした場合、11件目のデータから20件のデータを取得する", async () => {
         const repository = new TodoRepository();
-        const listDataResult = await repository.list({ page: 2 });
+        const todoList = await repository.list({ page: 2 });
 
-        expect(listDataResult.length).toEqual(10);
-        expect(listDataResult[0].id).toEqual(11);
-        expect(listDataResult[0].title).toEqual("ダミータイトル11");
-        expect(listDataResult[0].body).toEqual("ダミーボディ11");
+        expect(todoList.length).toEqual(10);
+        expect(todoList[0].id).toEqual(11);
+        expect(todoList[0].title).toEqual("ダミータイトル11");
+        expect(todoList[0].body).toEqual("ダミーボディ11");
       });
       it("listメソッドを実行時、パラメーターの指定(count=5)をした場合、先頭から5件のデータを取得する", async () => {
         const repository = new TodoRepository();
-        const listDataResult = await repository.list({ count: 5 });
+        const todoList = await repository.list({ count: 5 });
 
-        expect(listDataResult.length).toEqual(5);
-        expect(listDataResult[4].id).toEqual(5);
-        expect(listDataResult[4].title).toEqual("ダミータイトル5");
-        expect(listDataResult[4].body).toEqual("ダミーボディ5");
+        expect(todoList.length).toEqual(5);
+        expect(todoList[4].id).toEqual(5);
+        expect(todoList[4].title).toEqual("ダミータイトル5");
+        expect(todoList[4].body).toEqual("ダミーボディ5");
       });
       it("listメソッドを実行時、パラメーターの指定(page=2,count=3)をした場合、4件目のデータから3件のデータを取得する", async () => {
         const repository = new TodoRepository();
-        const listDataResult = await repository.list({ page: 2, count: 3 });
+        const todoList = await repository.list({ page: 2, count: 3 });
 
-        expect(listDataResult.length).toEqual(3);
-        expect(listDataResult[0].id).toEqual(4);
-        expect(listDataResult[0].title).toEqual("ダミータイトル4");
-        expect(listDataResult[0].body).toEqual("ダミーボディ4");
+        expect(todoList.length).toEqual(3);
+        expect(todoList[0].id).toEqual(4);
+        expect(todoList[0].title).toEqual("ダミータイトル4");
+        expect(todoList[0].body).toEqual("ダミーボディ4");
       });
       it("findメソッドを実行すると、DBに保持されているデータから、一件の値を取得する事ができる", async () => {
         const repository = new TodoRepository();
 
-        const initialDataResult = await repository.find(1);
-        const secondDataResult = await repository.find(2);
+        const initialTodo = await repository.find(1);
+        const secondTodo = await repository.find(2);
 
-        expect(initialDataResult?.id).toEqual(1);
-        expect(initialDataResult?.title).toEqual("ダミータイトル1");
-        expect(initialDataResult?.body).toEqual("ダミーボディ1");
-        expect(initialDataResult?.createdAt).toBeInstanceOf(Date);
-        expect(initialDataResult?.updatedAt).toBeInstanceOf(Date);
+        expect(initialTodo?.id).toEqual(1);
+        expect(initialTodo?.title).toEqual("ダミータイトル1");
+        expect(initialTodo?.body).toEqual("ダミーボディ1");
+        expect(initialTodo?.createdAt).toBeInstanceOf(Date);
+        expect(initialTodo?.updatedAt).toBeInstanceOf(Date);
 
-        expect(secondDataResult?.id).toEqual(2);
-        expect(secondDataResult?.title).toEqual("ダミータイトル2");
-        expect(secondDataResult?.body).toEqual("ダミーボディ2");
-        expect(secondDataResult?.createdAt).toBeInstanceOf(Date);
-        expect(secondDataResult?.updatedAt).toBeInstanceOf(Date);
+        expect(secondTodo?.id).toEqual(2);
+        expect(secondTodo?.title).toEqual("ダミータイトル2");
+        expect(secondTodo?.body).toEqual("ダミーボディ2");
+        expect(secondTodo?.createdAt).toBeInstanceOf(Date);
+        expect(secondTodo?.updatedAt).toBeInstanceOf(Date);
       });
       it("updateメソッドを実行すると、DB内のデータを更新する事ができる。", async () => {
         const repository = new TodoRepository();
 
-        const latestResult: Todo = await repository.update({
+        const updatedTodo: Todo = await repository.update({
           id: 1,
           title: "変更後のタイトル",
           body: "変更後のボディ",
         });
 
-        expect(latestResult).toEqual({
+        expect(updatedTodo).toEqual({
           id: 1,
           title: "変更後のタイトル",
           body: "変更後のボディ",
-          createdAt: latestResult.createdAt,
-          updatedAt: latestResult.updatedAt,
+          createdAt: updatedTodo.createdAt,
+          updatedAt: updatedTodo.updatedAt,
         });
       });
       it("updateメソッドを実行した後は、updatedAtの方がcreatedAtよりも新しい時間になっている。", async () => {
         const repository = new TodoRepository();
 
-        const latestDateResult = await repository.update({
+        const updatedTodo = await repository.update({
           id: 1,
           title: "変更後のタイトル",
           body: "変更後のボディ",
         });
 
-        expect(
-          latestDateResult.createdAt < latestDateResult.updatedAt
-        ).toBeTruthy();
+        expect(updatedTodo.createdAt < updatedTodo.updatedAt).toBeTruthy();
       });
       it("deleteメソッドを実行すると、DB内の指定した(ID)データを削除する事ができる。", async () => {
         const repository = new TodoRepository();
 
-        const dbOldDataResult = await repository.list();
-        const deletedDataResult = await repository.delete(1);
-        const dbCurrentDataResult = await repository.list();
+        const oldTodos = await repository.list();
+        const deletedTodo = await repository.delete(1);
+        const newTodos = await repository.list();
 
-        const oldDataId = dbOldDataResult.map((todo) => todo.id);
-        const currentDataId = dbCurrentDataResult.map((todo) => todo.id);
+        const oldTodoIds = oldTodos.map((todo) => todo.id);
+        const newTodoIds = newTodos.map((todo) => todo.id);
 
-        expect(deletedDataResult.id).toEqual(1);
-        expect(oldDataId).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        expect(currentDataId).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+        expect(deletedTodo.id).toEqual(1);
+        expect(oldTodoIds).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        expect(newTodoIds).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
       });
     });
   });

--- a/src/controllers/todos/DeleteTodoController.ts
+++ b/src/controllers/todos/DeleteTodoController.ts
@@ -14,6 +14,7 @@ export class DeleteTodoController {
 
     try {
       const responseData = await this.repository.delete(parsedId);
+
       res.status(200).json(responseData);
     } catch (_) {
       const errorObj = {

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -102,8 +102,10 @@ export class TodoRepository {
       throw new Error("存在しないIDを指定しました。");
     }
 
-    await prisma.todo.delete({
+    const responseDeleteItem = prisma.todo.delete({
       where: { id: id },
     });
+
+    return responseDeleteItem;
   }
 }


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

今回の修正は、まず、
全てのテストファイルの実行時に、
並列処理を行わない設定(--runInBandをscriptsに追加)を
行いました。

これにより、npm testで全てのテストを走らせても、
問題なくテストが通るようになりました。
![screenshot 86](https://github.com/user-attachments/assets/3bf1f5af-1306-428e-9187-affab7b06f6c)


コチラに関して、質問の回答時に、前田さんの指摘がありましたが↓
（テスト数がどんどん増えてきたら、テストにかかる時間が長くなるというデメリットもありますが、今のところは問題ないと思います。）
今のところ問題ないとの事なので、今回はコチラの対応をさせて
頂きました。

他は、beforの修正と、それに付随して
Deleteメソッドで削除した内容が
レスポンスで受け取れなくなったので、
getで取得した値で、削除できたかの判定をするテストに
変更しました。

よろしくお願いします。
