### PR TITLE
【UpdateTodoController.spec.tsのテストファイル修正】～ユニットテスト～

### DIFF
--- a/src/__test__/controllers/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/UpdateTodoController.spec.ts
@@ -1,0 +1,86 @@
+import { UpdateTodoController } from "../../../controllers/todos/UpdateTodoController";
+import { MockRepository } from "../../helper/mocks/MockTodoRepository";
+import { createMockRequest } from "../../helper/mocks/request";
+import { createMockResponse } from "../../helper/mocks/response";
+
+const repository = new MockRepository();
+const todoUpdateController = new UpdateTodoController(repository);
+
+describe("【ユニットテスト】 Todo一件の更新", () => {
+  describe("成功パターン", () => {
+    beforeAll(async () => {
+      for (let i = 1; i <= 2; i++) {
+        await repository.save({
+          title: `ダミータイトル${i}`,
+          body: `ダミーボディ${i}`,
+        });
+      }
+    });
+    it("id:1のデータ更新(タイトルのみ)", async () => {
+      const req = createMockRequest({ title: "変更後のタイトル" }, { id: "1" });
+      const res = createMockResponse();
+
+      await todoUpdateController.update(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 1,
+        title: "変更後のタイトル",
+        body: "ダミーボディ1",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+    });
+    it("id:1のデータ更新(ボディのみ)", async () => {
+      const req = createMockRequest({ body: "変更後のボディ" }, { id: "1" });
+      const res = createMockResponse();
+
+      await todoUpdateController.update(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 1,
+        title: "変更後のタイトル",
+        body: "変更後のボディ",
+        createdAt: expect.any(Date),
+        updatedAt: new Date(),
+      });
+    });
+    it("id:2のデータ更新(タイトルとボディ)", async () => {
+      const req = createMockRequest(
+        { title: "変更後のタイトル", body: "変更後のボディ" },
+        { id: "2" }
+      );
+      const res = createMockResponse();
+
+      await todoUpdateController.update(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 2,
+        title: "変更後のタイトル",
+        body: "変更後のボディ",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+    });
+    describe("異常パターン", () => {
+      it("存在しないIDへのリクエストは、エラーメッセージとstatus404が返る", async () => {
+        const req = createMockRequest(
+          { title: "dummyTitle", body: "dummyBody" },
+          { id: "999" }
+        );
+        const res = createMockResponse();
+
+        await todoUpdateController.update(req, res);
+
+        expect(res.json).toHaveBeenCalledWith({
+          code: 404,
+          message: "Not found",
+          stat: "fail",
+        });
+        expect(res.status).toHaveBeenCalledWith(404);
+      });
+    });
+  });
+});

--- a/src/__test__/controllers/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/UpdateTodoController.spec.ts
@@ -43,7 +43,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
         title: "変更後のタイトル",
         body: "変更後のボディ",
         createdAt: expect.any(Date),
-        updatedAt: new Date(),
+        updatedAt: expect.any(Date),
       });
     });
     it("id:2のデータ更新(タイトルとボディ)", async () => {

--- a/src/__test__/controllers/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/UpdateTodoController.spec.ts
@@ -3,10 +3,9 @@ import { MockRepository } from "../../helper/mocks/MockTodoRepository";
 import { createMockRequest } from "../../helper/mocks/request";
 import { createMockResponse } from "../../helper/mocks/response";
 
-let controller: UpdateTodoController;
-let repository: MockRepository;
-
 describe("【ユニットテスト】 Todo一件の更新", () => {
+  let controller: UpdateTodoController;
+  let repository: MockRepository;
   describe("成功パターン", () => {
     beforeEach(async () => {
       repository = new MockRepository();

--- a/src/__test__/controllers/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/UpdateTodoController.spec.ts
@@ -3,12 +3,15 @@ import { MockRepository } from "../../helper/mocks/MockTodoRepository";
 import { createMockRequest } from "../../helper/mocks/request";
 import { createMockResponse } from "../../helper/mocks/response";
 
-const repository = new MockRepository();
-const todoUpdateController = new UpdateTodoController(repository);
+let controller: UpdateTodoController;
+let repository: MockRepository;
 
 describe("【ユニットテスト】 Todo一件の更新", () => {
   describe("成功パターン", () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
+      repository = new MockRepository();
+      controller = new UpdateTodoController(repository);
+
       for (let i = 1; i <= 2; i++) {
         await repository.save({
           title: `ダミータイトル${i}`,
@@ -20,7 +23,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
       const req = createMockRequest({ title: "変更後のタイトル" }, { id: "1" });
       const res = createMockResponse();
 
-      await todoUpdateController.update(req, res);
+      await controller.update(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
@@ -35,12 +38,12 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
       const req = createMockRequest({ body: "変更後のボディ" }, { id: "1" });
       const res = createMockResponse();
 
-      await todoUpdateController.update(req, res);
+      await controller.update(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
         id: 1,
-        title: "変更後のタイトル",
+        title: "ダミータイトル1",
         body: "変更後のボディ",
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
@@ -53,7 +56,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
       );
       const res = createMockResponse();
 
-      await todoUpdateController.update(req, res);
+      await controller.update(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
@@ -72,7 +75,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
         );
         const res = createMockResponse();
 
-        await todoUpdateController.update(req, res);
+        await controller.update(req, res);
 
         expect(res.json).toHaveBeenCalledWith({
           code: 404,

--- a/src/__test__/helper/mocks/MockTodoRepository.ts
+++ b/src/__test__/helper/mocks/MockTodoRepository.ts
@@ -69,7 +69,16 @@ export class MockRepository implements ITodoRepository {
   }
 
   async update({ id, title, body }: TodoUpdatedInput): Promise<Todo> {
-    throw new Error("Method not implemented.");
+    const updatedItem = this.todos.find((todo) => todo.id === id);
+    if (!updatedItem) {
+      throw new Error("存在しないIDを指定しました。");
+    }
+
+    updatedItem.title = title ? title : updatedItem.title;
+    updatedItem.body = body ? body : updatedItem.body;
+    updatedItem.createdAt = new Date();
+
+    return updatedItem;
   }
 
   async delete(id: number): Promise<Todo> {

--- a/src/__test__/helper/mocks/MockTodoRepository.ts
+++ b/src/__test__/helper/mocks/MockTodoRepository.ts
@@ -76,7 +76,7 @@ export class MockRepository implements ITodoRepository {
 
     updatedItem.title = title ? title : updatedItem.title;
     updatedItem.body = body ? body : updatedItem.body;
-    updatedItem.createdAt = new Date();
+    updatedItem.updatedAt = new Date();
 
     return updatedItem;
   }

--- a/src/controllers/todos/UpdateTodoController.ts
+++ b/src/controllers/todos/UpdateTodoController.ts
@@ -1,10 +1,10 @@
 import type { Request, Response } from "express";
-import { TodoRepository } from "../../repositories/TodoRepository";
+import type { ITodoRepository } from "../../repositories/ITodoRepository";
 
 export class UpdateTodoController {
-  private repository: TodoRepository;
+  private repository: ITodoRepository;
 
-  constructor(repository: TodoRepository) {
+  constructor(repository: ITodoRepository) {
     this.repository = repository;
   }
 


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

今回の修正は、他ユニットテスト同様に、
コントローラーの依存を抽象に依存(リポジトリにインターフェースを注入)と、
モックのアップデートメソッドをテスト用に修正しました。

テストの内容は、コントローラーのupdateメソッドを実行すると、
事前データのid1とid2が更新されるものです。

異常パターンは、
不正idを入れると、
status404とエラーオブジェクトが返るものです。

よろしくお願いします。
