### PR TITLE
【DeleteTodoController.spec.tsのテストファイル修正】～ユニットテスト～ 

### DIFF
--- a/src/__test__/controllers/todos/DeleteTodoController.spec.ts
+++ b/src/__test__/controllers/todos/DeleteTodoController.spec.ts
@@ -6,10 +6,6 @@ import { createMockResponse } from "../../helper/mocks/response";
 describe("【ユニットテスト】Todo1件の削除", () => {
   let controller: DeleteTodoController;
   let repository: MockRepository;
-
-  let dbOldData;
-  let dbCurrentData;
-
   describe("成功パターン", () => {
     beforeEach(async () => {
       repository = new MockRepository();
@@ -26,9 +22,9 @@ describe("【ユニットテスト】Todo1件の削除", () => {
       const req = createMockRequest({}, { id: "1" });
       const res = createMockResponse();
 
-      dbOldData = repository.list();
+      const dbOldData = repository.list();
       await controller.delete(req, res);
-      dbCurrentData = repository.list();
+      const dbCurrentData = repository.list();
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
@@ -45,9 +41,9 @@ describe("【ユニットテスト】Todo1件の削除", () => {
       const req = createMockRequest({}, { id: "2" });
       const res = createMockResponse();
 
-      dbOldData = repository.list();
+      const dbOldData = repository.list();
       await controller.delete(req, res);
-      dbCurrentData = repository.list();
+      const dbCurrentData = repository.list();
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({

--- a/src/__test__/controllers/todos/DeleteTodoController.spec.ts
+++ b/src/__test__/controllers/todos/DeleteTodoController.spec.ts
@@ -1,0 +1,79 @@
+import { DeleteTodoController } from "../../../controllers/todos/DeleteTodoController";
+import { MockRepository } from "../../helper/mocks/MockTodoRepository";
+import { createMockRequest } from "../../helper/mocks/request";
+import { createMockResponse } from "../../helper/mocks/response";
+
+describe("【ユニットテスト】Todo1件の削除", () => {
+  let controller: DeleteTodoController;
+  let repository: MockRepository;
+
+  let dbOldData;
+  let dbCurrentData;
+
+  describe("成功パターン", () => {
+    beforeEach(async () => {
+      repository = new MockRepository();
+      controller = new DeleteTodoController(repository);
+
+      for (let i = 1; i <= 2; i++) {
+        await repository.save({
+          title: `ダミータイトル${i}`,
+          body: `ダミーボディ${i}`,
+        });
+      }
+    });
+    it("仮DB(todos)から一件のTodoが削除され、削除したTodoデータ(id:1)が返る", async () => {
+      const req = createMockRequest({}, { id: "1" });
+      const res = createMockResponse();
+
+      dbOldData = repository.list();
+      await controller.delete(req, res);
+      dbCurrentData = repository.list();
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 1,
+        title: "ダミータイトル1",
+        body: "ダミーボディ1",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+      expect((await dbOldData).length).toEqual(2);
+      expect((await dbCurrentData).length).toEqual(1);
+    });
+    it("仮DB(todos)から一件のTodoが削除され、削除したTodoデータ(id:2)が返る", async () => {
+      const req = createMockRequest({}, { id: "2" });
+      const res = createMockResponse();
+
+      dbOldData = repository.list();
+      await controller.delete(req, res);
+      dbCurrentData = repository.list();
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 2,
+        title: "ダミータイトル2",
+        body: "ダミーボディ2",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+      expect((await dbOldData).length).toEqual(2);
+      expect((await dbCurrentData).length).toEqual(1);
+    });
+  });
+  describe("異常パターン", () => {
+    it("存在しないIDへのリクエストは、エラーメッセージとstatus404が返る", async () => {
+      const req = createMockRequest({}, { id: "999" });
+      const res = createMockResponse();
+
+      await controller.delete(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        code: 404,
+        message: "Not found",
+        stat: "fail",
+      });
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+});

--- a/src/__test__/helper/mocks/MockTodoRepository.ts
+++ b/src/__test__/helper/mocks/MockTodoRepository.ts
@@ -58,7 +58,7 @@ export class MockRepository implements ITodoRepository {
     return todoItems;
   }
 
-  async find(id: number): Promise<Todo | null> {
+  async find(id: number): Promise<Todo> {
     const todoItem = this.todos.find((todo) => todo.id === id);
 
     if (!todoItem) {

--- a/src/__test__/helper/mocks/MockTodoRepository.ts
+++ b/src/__test__/helper/mocks/MockTodoRepository.ts
@@ -82,6 +82,14 @@ export class MockRepository implements ITodoRepository {
   }
 
   async delete(id: number): Promise<Todo> {
-    throw new Error("Method not implemented.");
+    const deleteId = this.todos.findIndex((todo) => todo.id === id);
+
+    if (deleteId === -1) {
+      throw new Error();
+    }
+
+    const deletedItem = this.todos.splice(deleteId, 1)[0];
+
+    return deletedItem;
   }
 }

--- a/src/controllers/todos/DeleteTodoController.ts
+++ b/src/controllers/todos/DeleteTodoController.ts
@@ -1,10 +1,10 @@
 import type { Request, Response } from "express";
-import { TodoRepository } from "../../repositories/TodoRepository";
+import type { ITodoRepository } from "../../repositories/ITodoRepository";
 
 export class DeleteTodoController {
-  private repository: TodoRepository;
+  private repository: ITodoRepository;
 
-  constructor(repository: TodoRepository) {
+  constructor(repository: ITodoRepository) {
     this.repository = repository;
   }
 

--- a/src/repositories/ITodoRepository.ts
+++ b/src/repositories/ITodoRepository.ts
@@ -5,7 +5,7 @@ import type { TodoUpdatedInput } from "../types/TodoRequest.type";
 export interface ITodoRepository {
   save(inputData: TodoInput): Promise<Todo>;
   list(todoListRange?: { page?: number; count?: number }): Promise<Todo[]>;
-  find(id: number): Promise<Todo | null>;
+  find(id: number): Promise<Todo>;
   update({ id, title, body }: TodoUpdatedInput): Promise<Todo>;
-  delete(id: number): Promise<Todo | null>;
+  delete(id: number): Promise<Todo>;
 }

--- a/src/repositories/ITodoRepository.ts
+++ b/src/repositories/ITodoRepository.ts
@@ -7,5 +7,5 @@ export interface ITodoRepository {
   list(todoListRange?: { page?: number; count?: number }): Promise<Todo[]>;
   find(id: number): Promise<Todo | null>;
   update({ id, title, body }: TodoUpdatedInput): Promise<Todo>;
-  delete(id: number): Promise<Todo>;
+  delete(id: number): Promise<Todo | null>;
 }


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

今回の修正は、他ユニットテスト同様に、
コントローラーの依存を抽象に依存(リポジトリにインターフェースを注入)と、
モックのdeleteメソッドの修正を行いました。

前回、前田さんにご指示頂いた、テスト間の依存関係がなく
テストが行えるようにしました。

 let dbOldDataとlet dbCurrentDataを
用意し、Todo一件の削除後のデータ件数を
テストしました。

異常パターンも、他のコントローラーのユニットテスト同様に、
ステータスコード(404)とエラーオブジェクトが返るテストを
行いました。

よろしくお願いします。