### PR TITLE
【ユニットテスト(todoController)のファイル修正】～モックを利用した簡略化テスト～

### DIFF
--- a/src/__test__/controllers/todos/CreateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/CreateTodoController.spec.ts
@@ -3,12 +3,11 @@ import { MockRepository } from "../../helper/mocks/MockTodoRepository";
 import { createMockRequest } from "../../helper/mocks/request";
 import { createMockResponse } from "../../helper/mocks/response";
 
-const repository = new MockRepository();
-const todoCreateController = new CreateTodoController(repository);
-
 describe("【ユニットテスト】Todo1件新規作成", () => {
-  describe("成功パターン", () => {
-    it("Todo(json)とstatus 200が返る", async () => {
+  const repository = new MockRepository();
+  const todoCreateController = new CreateTodoController(repository);
+  describe("【成功パターン】Todo(json)とstatus 200が返る", () => {
+    it("saveメソッドが1回実行されて、仮DB(argumentStack)から、一件のTodoデータが返る", async () => {
       const req = createMockRequest({
         title: "ダミータイトル",
         body: "ダミーボディ",
@@ -16,6 +15,15 @@ describe("【ユニットテスト】Todo1件新規作成", () => {
       const res = createMockResponse();
 
       await todoCreateController.create(req, res);
+
+      expect(repository.getCallCount()).toEqual(1);
+      expect(repository.getArgumentStack(0)).toEqual({
+        id: 1,
+        title: "ダミータイトル",
+        body: "ダミーボディ",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({

--- a/src/__test__/controllers/todos/CreateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/CreateTodoController.spec.ts
@@ -3,11 +3,11 @@ import { MockRepository } from "../../helper/mocks/MockTodoRepository";
 import { createMockRequest } from "../../helper/mocks/request";
 import { createMockResponse } from "../../helper/mocks/response";
 
-describe("【ユニットテスト】Todo1件新規作成", () => {
+describe("【ユニットテスト】Todo1件の新規作成", () => {
   const repository = new MockRepository();
   const todoCreateController = new CreateTodoController(repository);
   describe("【成功パターン】Todo(json)とstatus 200が返る", () => {
-    it("saveメソッドが1回実行されて、仮DB(argumentStack)から、一件のTodoデータが返る", async () => {
+    it("saveメソッドが1回実行され、仮DB(argumentStack)から、1件のTodoデータが返る", async () => {
       const req = createMockRequest({
         title: "ダミータイトル",
         body: "ダミーボディ",

--- a/src/__test__/controllers/todos/DeleteTodoController.spec.ts
+++ b/src/__test__/controllers/todos/DeleteTodoController.spec.ts
@@ -11,7 +11,7 @@ describe("【ユニットテスト】Todo1件の削除", () => {
       repository = new MockRepository();
       controller = new DeleteTodoController(repository);
     });
-    it("deleteメソッドが1回実行されて、削除したTodoデータが返る(id:1)", async () => {
+    it("deleteメソッドが1回実行され、削除したTodoデータが返る(id:1)", async () => {
       const req = createMockRequest({}, { id: "1" });
       const res = createMockResponse();
 
@@ -28,7 +28,7 @@ describe("【ユニットテスト】Todo1件の削除", () => {
         updatedAt: expect.any(Date),
       });
     });
-    it("deleteメソッドが1回実行されて、削除したTodoデータが返る(id:2)", async () => {
+    it("deleteメソッドが1回実行され、削除したTodoデータが返る(id:2)", async () => {
       const req = createMockRequest({}, { id: "2" });
       const res = createMockResponse();
 
@@ -45,22 +45,20 @@ describe("【ユニットテスト】Todo1件の削除", () => {
         updatedAt: expect.any(Date),
       });
     });
-  });
-  describe("異常パターン", () => {
-    it("存在しないIDへのリクエストは、エラーメッセージとstatus404が返る", async () => {
-      const req = createMockRequest({}, { id: "999" });
-      const res = createMockResponse();
+    describe("異常パターン", () => {
+      it("存在しないIDへのリクエストは、エラーメッセージとstatus404が返る", async () => {
+        const req = createMockRequest({}, { id: "999" });
+        const res = createMockResponse();
 
-      await controller.delete(req, res);
+        await controller.delete(req, res);
 
-      expect(repository.getCallCount()).toEqual(1);
-
-      expect(res.json).toHaveBeenCalledWith({
-        code: 404,
-        message: "Not found",
-        stat: "fail",
+        expect(res.json).toHaveBeenCalledWith({
+          code: 404,
+          message: "Not found",
+          stat: "fail",
+        });
+        expect(res.status).toHaveBeenCalledWith(404);
       });
-      expect(res.status).toHaveBeenCalledWith(404);
     });
   });
 });

--- a/src/__test__/controllers/todos/DeleteTodoController.spec.ts
+++ b/src/__test__/controllers/todos/DeleteTodoController.spec.ts
@@ -6,25 +6,18 @@ import { createMockResponse } from "../../helper/mocks/response";
 describe("【ユニットテスト】Todo1件の削除", () => {
   let controller: DeleteTodoController;
   let repository: MockRepository;
-  describe("成功パターン", () => {
+  describe("【成功パターン】削除したTodoデータ(jsonとstatus200)が返る", () => {
     beforeEach(async () => {
       repository = new MockRepository();
       controller = new DeleteTodoController(repository);
-
-      for (let i = 1; i <= 2; i++) {
-        await repository.save({
-          title: `ダミータイトル${i}`,
-          body: `ダミーボディ${i}`,
-        });
-      }
     });
-    it("仮DB(todos)から一件のTodoが削除され、削除したTodoデータ(id:1)が返る", async () => {
+    it("deleteメソッドが1回実行されて、削除したTodoデータが返る(id:1)", async () => {
       const req = createMockRequest({}, { id: "1" });
       const res = createMockResponse();
 
-      const dbOldData = repository.list();
       await controller.delete(req, res);
-      const dbCurrentData = repository.list();
+
+      expect(repository.getCallCount()).toEqual(1);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
@@ -34,16 +27,14 @@ describe("【ユニットテスト】Todo1件の削除", () => {
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
       });
-      expect((await dbOldData).length).toEqual(2);
-      expect((await dbCurrentData).length).toEqual(1);
     });
-    it("仮DB(todos)から一件のTodoが削除され、削除したTodoデータ(id:2)が返る", async () => {
+    it("deleteメソッドが1回実行されて、削除したTodoデータが返る(id:2)", async () => {
       const req = createMockRequest({}, { id: "2" });
       const res = createMockResponse();
 
-      const dbOldData = repository.list();
       await controller.delete(req, res);
-      const dbCurrentData = repository.list();
+
+      expect(repository.getCallCount()).toEqual(1);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
@@ -53,8 +44,6 @@ describe("【ユニットテスト】Todo1件の削除", () => {
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
       });
-      expect((await dbOldData).length).toEqual(2);
-      expect((await dbCurrentData).length).toEqual(1);
     });
   });
   describe("異常パターン", () => {
@@ -63,6 +52,8 @@ describe("【ユニットテスト】Todo1件の削除", () => {
       const res = createMockResponse();
 
       await controller.delete(req, res);
+
+      expect(repository.getCallCount()).toEqual(1);
 
       expect(res.json).toHaveBeenCalledWith({
         code: 404,

--- a/src/__test__/controllers/todos/GetTodoController.spec.ts
+++ b/src/__test__/controllers/todos/GetTodoController.spec.ts
@@ -3,24 +3,24 @@ import { MockRepository } from "../../helper/mocks/MockTodoRepository";
 import { createMockRequest } from "../../helper/mocks/request";
 import { createMockResponse } from "../../helper/mocks/response";
 
-const repository = new MockRepository();
-const todoGetController = new GetTodoController(repository);
-
 describe("【ユニットテスト】Todo1件を取得", () => {
-  describe("成功パターン", () => {
-    beforeAll(async () => {
-      for (let i = 1; i <= 2; i++) {
-        await repository.save({
-          title: `ダミータイトル${i}`,
-          body: `ダミーボディ${i}`,
-        });
-      }
-    });
-    it("id:1のTodoデータ(jsonとstatus200)が返る", async () => {
+  const repository = new MockRepository();
+  const todoGetController = new GetTodoController(repository);
+  describe("【成功パターン】Todoデータ(jsonとstatus200)が返る", () => {
+    it("findメソッドが1回実行されて、仮DB(argumentStack)から、id:1のTodoを取得する", async () => {
       const req = createMockRequest({}, { id: "1" });
       const res = createMockResponse();
 
       await todoGetController.find(req, res);
+
+      expect(repository.getCallCount()).toEqual(1);
+      expect(repository.getArgumentStack(0)).toEqual({
+        id: 1,
+        title: "ダミータイトル1",
+        body: "ダミーボディ1",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
@@ -31,11 +31,20 @@ describe("【ユニットテスト】Todo1件を取得", () => {
         updatedAt: expect.any(Date),
       });
     });
-    it("id:2のTodoデータ(jsonとstatus200)が返る", async () => {
+    it("findメソッドが2回実行されて、仮DB(argumentStack)から、id:2のTodoを取得する", async () => {
       const req = createMockRequest({}, { id: "2" });
       const res = createMockResponse();
 
       await todoGetController.find(req, res);
+
+      expect(repository.getCallCount()).toEqual(2);
+      expect(repository.getArgumentStack(1)).toEqual({
+        id: 2,
+        title: "ダミータイトル2",
+        body: "ダミーボディ2",
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({

--- a/src/__test__/controllers/todos/GetTodoController.spec.ts
+++ b/src/__test__/controllers/todos/GetTodoController.spec.ts
@@ -4,14 +4,18 @@ import { createMockRequest } from "../../helper/mocks/request";
 import { createMockResponse } from "../../helper/mocks/response";
 
 describe("【ユニットテスト】Todo1件を取得", () => {
-  const repository = new MockRepository();
-  const todoGetController = new GetTodoController(repository);
+  let controller: GetTodoController;
+  let repository: MockRepository;
   describe("【成功パターン】Todoデータ(jsonとstatus200)が返る", () => {
-    it("findメソッドが1回実行されて、仮DB(argumentStack)から、id:1のTodoを取得する", async () => {
+    beforeEach(async () => {
+      repository = new MockRepository();
+      controller = new GetTodoController(repository);
+    });
+    it("findメソッドが1回実行され、仮DB(argumentStack)からID:1のTodoを取得する", async () => {
       const req = createMockRequest({}, { id: "1" });
       const res = createMockResponse();
 
-      await todoGetController.find(req, res);
+      await controller.find(req, res);
 
       expect(repository.getCallCount()).toEqual(1);
       expect(repository.getArgumentStack(0)).toEqual({
@@ -31,13 +35,13 @@ describe("【ユニットテスト】Todo1件を取得", () => {
         updatedAt: expect.any(Date),
       });
     });
-    it("findメソッドが2回実行されて、仮DB(argumentStack)から、id:2のTodoを取得する", async () => {
+    it("findメソッドが2回実行され、仮DB(argumentStack)からID:2のTodoを取得する", async () => {
       const req = createMockRequest({}, { id: "2" });
       const res = createMockResponse();
 
-      await todoGetController.find(req, res);
+      await controller.find(req, res);
 
-      expect(repository.getCallCount()).toEqual(2);
+      expect(repository.getCallCount()).toEqual(1);
       expect(repository.getArgumentStack(1)).toEqual({
         id: 2,
         title: "ダミータイトル2",
@@ -61,7 +65,9 @@ describe("【ユニットテスト】Todo1件を取得", () => {
       const req = createMockRequest({ id: "999" });
       const res = createMockResponse();
 
-      await todoGetController.find(req, res);
+      await controller.find(req, res);
+
+      expect(repository.getCallCount()).toEqual(1);
 
       expect(res.json).toHaveBeenCalledWith({
         code: 404,

--- a/src/__test__/controllers/todos/GetTodosController.spec.ts
+++ b/src/__test__/controllers/todos/GetTodosController.spec.ts
@@ -4,14 +4,18 @@ import { createMockRequest } from "../../helper/mocks/request";
 import { createMockResponse } from "../../helper/mocks/response";
 
 describe("【ユニットテスト】 Todo一覧取得", () => {
-  const repository = new MockRepository();
-  const todosGetController = new GetTodosController(repository);
+  let controller: GetTodosController;
+  let repository: MockRepository;
   describe("【成功パターン】Todoデータ(jsonとstatus200)が返る", () => {
+    beforeEach(async () => {
+      repository = new MockRepository();
+      controller = new GetTodosController(repository);
+    });
     it("Todo一覧を取得できる", async () => {
       const req = createMockRequest();
       const res = createMockResponse();
 
-      await todosGetController.list(req, res);
+      await controller.list(req, res);
 
       expect(repository.getCallCount()).toEqual(1);
 
@@ -35,25 +39,25 @@ describe("【ユニットテスト】 Todo一覧取得", () => {
       const req = createMockRequest({ page: 2, count: 5 });
       const res = createMockResponse();
 
-      await todosGetController.list(req, res);
+      await controller.list(req, res);
 
-      expect(repository.getCallCount()).toEqual(2);
+      expect(repository.getCallCount()).toEqual(1);
     });
     it("パラメーターの指定(page=2)をした場合、11件目のデータから20件のデータを取得する", async () => {
       const req = createMockRequest({ page: 2 });
       const res = createMockResponse();
 
-      await todosGetController.list(req, res);
+      await controller.list(req, res);
 
-      expect(repository.getCallCount()).toEqual(3);
+      expect(repository.getCallCount()).toEqual(1);
     });
     it("パラメーターの指定(count=3)をした場合、先頭から3件のデータを取得する", async () => {
       const req = createMockRequest({ count: 3 });
       const res = createMockResponse();
 
-      await todosGetController.list(req, res);
+      await controller.list(req, res);
 
-      expect(repository.getCallCount()).toEqual(4);
+      expect(repository.getCallCount()).toEqual(1);
     });
   });
 });

--- a/src/__test__/controllers/todos/GetTodosController.spec.ts
+++ b/src/__test__/controllers/todos/GetTodosController.spec.ts
@@ -3,75 +3,26 @@ import { MockRepository } from "../../helper/mocks/MockTodoRepository";
 import { createMockRequest } from "../../helper/mocks/request";
 import { createMockResponse } from "../../helper/mocks/response";
 
-const repository = new MockRepository();
-const todosGetController = new GetTodosController(repository);
-
 describe("【ユニットテスト】 Todo一覧取得", () => {
-  describe("DBにデータなし", () => {
-    it("空配列が返る", async () => {
+  const repository = new MockRepository();
+  const todosGetController = new GetTodosController(repository);
+  describe("【成功パターン】Todoデータ(jsonとstatus200)が返る", () => {
+    it("Todo一覧を取得できる", async () => {
       const req = createMockRequest();
       const res = createMockResponse();
 
       await todosGetController.list(req, res);
 
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith([]);
-    });
-  });
-  describe("DBにデータあり", () => {
-    it("Todo一覧を取得できる、", async () => {
-      for (let i = 1; i <= 3; i++) {
-        await repository.save({
-          title: `ダミータイトル${i}`,
-          body: `ダミーボディ${i}`,
-        });
-      }
-
-      const req = createMockRequest();
-      const res = createMockResponse();
-
-      await todosGetController.list(req, res);
+      expect(repository.getCallCount()).toEqual(1);
 
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith([
-        {
-          id: 1,
-          title: "ダミータイトル1",
-          body: "ダミーボディ1",
-          createdAt: expect.any(Date),
-          updatedAt: expect.any(Date),
-        },
-        {
-          id: 2,
-          title: "ダミータイトル2",
-          body: "ダミーボディ2",
-          createdAt: expect.any(Date),
-          updatedAt: expect.any(Date),
-        },
-        {
-          id: 3,
-          title: "ダミータイトル3",
-          body: "ダミーボディ3",
-          createdAt: expect.any(Date),
-          updatedAt: expect.any(Date),
-        },
-      ]);
-    });
-    it("パラメーターの指定(page=2,count=5)をした場合、6件目のデータから10件のデータを取得する", async () => {
-      for (let i = 4; i <= 20; i++) {
-        await repository.save({
-          title: `ダミータイトル${i}`,
-          body: `ダミーボディ${i}`,
-        });
-      }
-
-      const req = createMockRequest({ page: 2, count: 5 });
-      const res = createMockResponse();
-
-      await todosGetController.list(req, res);
-
       expect(res.json).toHaveBeenCalledWith(
         expect.arrayContaining([
+          expect.objectContaining({ id: 1 }),
+          expect.objectContaining({ id: 2 }),
+          expect.objectContaining({ id: 3 }),
+          expect.objectContaining({ id: 4 }),
+          expect.objectContaining({ id: 5 }),
           expect.objectContaining({ id: 6 }),
           expect.objectContaining({ id: 7 }),
           expect.objectContaining({ id: 8 }),
@@ -80,26 +31,21 @@ describe("【ユニットテスト】 Todo一覧取得", () => {
         ])
       );
     });
+    it("パラメーターの指定(page=2,count=5)をした場合、6件目のデータから10件のデータを取得する", async () => {
+      const req = createMockRequest({ page: 2, count: 5 });
+      const res = createMockResponse();
+
+      await todosGetController.list(req, res);
+
+      expect(repository.getCallCount()).toEqual(2);
+    });
     it("パラメーターの指定(page=2)をした場合、11件目のデータから20件のデータを取得する", async () => {
       const req = createMockRequest({ page: 2 });
       const res = createMockResponse();
 
       await todosGetController.list(req, res);
 
-      expect(res.json).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ id: 11 }),
-          expect.objectContaining({ id: 12 }),
-          expect.objectContaining({ id: 13 }),
-          expect.objectContaining({ id: 14 }),
-          expect.objectContaining({ id: 15 }),
-          expect.objectContaining({ id: 16 }),
-          expect.objectContaining({ id: 17 }),
-          expect.objectContaining({ id: 18 }),
-          expect.objectContaining({ id: 19 }),
-          expect.objectContaining({ id: 20 }),
-        ])
-      );
+      expect(repository.getCallCount()).toEqual(3);
     });
     it("パラメーターの指定(count=3)をした場合、先頭から3件のデータを取得する", async () => {
       const req = createMockRequest({ count: 3 });
@@ -107,13 +53,7 @@ describe("【ユニットテスト】 Todo一覧取得", () => {
 
       await todosGetController.list(req, res);
 
-      expect(res.json).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ id: 1 }),
-          expect.objectContaining({ id: 2 }),
-          expect.objectContaining({ id: 3 }),
-        ])
-      );
+      expect(repository.getCallCount()).toEqual(4);
     });
   });
 });

--- a/src/__test__/controllers/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/UpdateTodoController.spec.ts
@@ -6,23 +6,18 @@ import { createMockResponse } from "../../helper/mocks/response";
 describe("【ユニットテスト】 Todo一件の更新", () => {
   let controller: UpdateTodoController;
   let repository: MockRepository;
-  describe("成功パターン", () => {
+  describe("【成功パターン】更新されたTodoデータ(jsonとstatus200)が返る", () => {
     beforeEach(async () => {
       repository = new MockRepository();
       controller = new UpdateTodoController(repository);
-
-      for (let i = 1; i <= 2; i++) {
-        await repository.save({
-          title: `ダミータイトル${i}`,
-          body: `ダミーボディ${i}`,
-        });
-      }
     });
-    it("id:1のデータ更新(タイトルのみ)", async () => {
+    it("updateメソッドが1回実行されて、更新されたTodoデータが返る(id:1タイトルのみ)", async () => {
       const req = createMockRequest({ title: "変更後のタイトル" }, { id: "1" });
       const res = createMockResponse();
 
       await controller.update(req, res);
+
+      expect(repository.getCallCount()).toEqual(1);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
@@ -33,11 +28,13 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
         updatedAt: expect.any(Date),
       });
     });
-    it("id:1のデータ更新(ボディのみ)", async () => {
+    it("updateメソッドが1回実行されて、更新されたTodoデータが返る(id:1のボディのみ)", async () => {
       const req = createMockRequest({ body: "変更後のボディ" }, { id: "1" });
       const res = createMockResponse();
 
       await controller.update(req, res);
+
+      expect(repository.getCallCount()).toEqual(1);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({
@@ -48,7 +45,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
         updatedAt: expect.any(Date),
       });
     });
-    it("id:2のデータ更新(タイトルとボディ)", async () => {
+    it("updateメソッドが1回実行されて、更新されたTodoデータが返る(id:2のタイトルとボディ) ", async () => {
       const req = createMockRequest(
         { title: "変更後のタイトル", body: "変更後のボディ" },
         { id: "2" }
@@ -56,6 +53,8 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
       const res = createMockResponse();
 
       await controller.update(req, res);
+
+      expect(repository.getCallCount()).toEqual(1);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({

--- a/src/__test__/controllers/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/UpdateTodoController.spec.ts
@@ -11,7 +11,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
       repository = new MockRepository();
       controller = new UpdateTodoController(repository);
     });
-    it("updateメソッドが1回実行されて、更新されたTodoデータが返る(id:1タイトルのみ)", async () => {
+    it("updateメソッドが1回実行され、更新されたTodoデータが返る(id:1タイトルのみ)", async () => {
       const req = createMockRequest({ title: "変更後のタイトル" }, { id: "1" });
       const res = createMockResponse();
 

--- a/src/__test__/helper/mocks/MockTodoRepository.ts
+++ b/src/__test__/helper/mocks/MockTodoRepository.ts
@@ -10,11 +10,37 @@ const DEFAULT_COUNT = 10;
 
 export class MockRepository implements ITodoRepository {
   private nextId: number;
-  private todos: Todo[] = [];
+  private callCount = 0;
+  private argumentStack: Todo[] = [];
 
   constructor() {
     this.nextId = 1;
-    this.todos = [];
+    this.argumentStack = [];
+  }
+
+  getCallCount() {
+    return this.callCount;
+  }
+
+  inputArgumentStack(inputTodoLength: number) {
+    for (let i = 1; i <= inputTodoLength; i++) {
+      const inputTodoData = {
+        id: this.nextId++,
+        title: `ダミータイトル${i}`,
+        body: `ダミーボディ${i}`,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      this.argumentStack.push(inputTodoData);
+    }
+  }
+
+  getArgumentStack(index: number) {
+    return this.argumentStack[index];
+  }
+
+  getArgumentStacks() {
+    return this.argumentStack;
   }
 
   async save(inputData: TodoInput): Promise<Todo> {
@@ -34,7 +60,9 @@ export class MockRepository implements ITodoRepository {
       updatedAt: new Date(),
     };
 
-    this.todos.push(savedTodo);
+    this.argumentStack.push(savedTodo);
+
+    this.callCount++;
 
     return savedTodo;
   }
@@ -52,24 +80,34 @@ export class MockRepository implements ITodoRepository {
       throw new Error("countは1以上の整数のみ");
     }
 
+    this.inputArgumentStack(20);
+
     const offset = (page - 1) * count;
-    const todoItems = this.todos.slice(offset, offset + count);
+    const todoItems = this.argumentStack.slice(offset, offset + count);
+
+    this.callCount++;
 
     return todoItems;
   }
 
   async find(id: number): Promise<Todo> {
-    const todoItem = this.todos.find((todo) => todo.id === id);
+    this.inputArgumentStack(2);
+
+    const todoItem = this.argumentStack.find((todo) => todo.id === id);
 
     if (!todoItem) {
       throw new Error();
     }
 
+    this.callCount++;
+
     return todoItem;
   }
 
   async update({ id, title, body }: TodoUpdatedInput): Promise<Todo> {
-    const updatedItem = this.todos.find((todo) => todo.id === id);
+    this.inputArgumentStack(2);
+
+    const updatedItem = this.argumentStack.find((todo) => todo.id === id);
     if (!updatedItem) {
       throw new Error("存在しないIDを指定しました。");
     }
@@ -78,17 +116,23 @@ export class MockRepository implements ITodoRepository {
     updatedItem.body = body ? body : updatedItem.body;
     updatedItem.updatedAt = new Date();
 
+    this.callCount++;
+
     return updatedItem;
   }
 
   async delete(id: number): Promise<Todo> {
-    const deleteId = this.todos.findIndex((todo) => todo.id === id);
+    this.inputArgumentStack(2);
+
+    const deleteId = this.argumentStack.findIndex((todo) => todo.id === id);
 
     if (deleteId === -1) {
       throw new Error();
     }
 
-    const deletedItem = this.todos.splice(deleteId, 1)[0];
+    const deletedItem = this.argumentStack.splice(deleteId, 1)[0];
+
+    this.callCount++;
 
     return deletedItem;
   }

--- a/src/__test__/helper/mocks/MockTodoRepository.ts
+++ b/src/__test__/helper/mocks/MockTodoRepository.ts
@@ -108,8 +108,9 @@ export class MockRepository implements ITodoRepository {
     this.inputArgumentStack(2);
 
     const updatedItem = this.argumentStack.find((todo) => todo.id === id);
+
     if (!updatedItem) {
-      throw new Error("存在しないIDを指定しました。");
+      throw new Error();
     }
 
     updatedItem.title = title ? title : updatedItem.title;


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

ファイル修正が多くなりました。

メソッド事に
プルリクを作成すれば
良かったです。

申し訳ございません💦

フィールド変数に
argumentStackとcallCountを
追加し、callCountを呼び出すメソッドを
追加しました。
![スクリーンショット 2024-08-10 155808](https://github.com/user-attachments/assets/37c75019-b2ce-4cb4-a5d7-7ed5730410ef)

各テストに、
beforeで入れていた事前データを
入れる為のメソッドと、取得する為の
メソッドを３つ追加しました。
![スクリーンショット 2024-08-10 155954](https://github.com/user-attachments/assets/a728a1ee-789e-4903-aa23-3b11566064d1)

コントローラーのテスト全般に、
リポジトリのメソッドが呼び出されたを
確認するテストを埋め込みました。
![スクリーンショット 2024-08-10 160413](https://github.com/user-attachments/assets/3112ab0d-570a-40cc-85ba-94450a2d1dae)

jsonとstatus コードのレスポンスについての
テスト内容は、listメソッド以外は
そのまま残しています。

よろしくお願いします。





