### PR TITLE
【ユニットテスト(DeleteTodoController)のファイル修正】～モックを利用した簡略化テスト～ 

### DIFF
--- a/src/controllers/todos/DeleteTodoController.ts
+++ b/src/controllers/todos/DeleteTodoController.ts
@@ -1,4 +1,5 @@
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
 
 import type { ITodoRepository } from "../../repositories/ITodoRepository";
 
@@ -9,22 +10,16 @@ export class DeleteTodoController {
     this.repository = repository;
   }
 
-  async delete(req: Request, res: Response) {
+  async delete(req: Request, res: Response, next: NextFunction) {
     const id = req.params.id;
     const parsedId = parseInt(id, 10);
 
     try {
       const responseData = await this.repository.delete(parsedId);
 
-      res.status(200).json(responseData);
-    } catch (_) {
-      const errorObj = {
-        code: 404,
-        message: "Not found",
-        stat: "fail",
-      };
-
-      res.status(404).json(errorObj);
+      res.status(StatusCodes.OK).json(responseData);
+    } catch (error) {
+      next(error);
     }
   }
 }

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -24,14 +24,6 @@ export class TodoRepository implements ITodoRepository {
   }
 
   async save(inputData: TodoInput) {
-    if (!inputData.title) {
-      throw new InvalidError("titleの内容は必須です。");
-    }
-
-    if (!inputData.body) {
-      throw new InvalidError("bodyの内容は必須です。");
-    }
-
     const todoData: Todo = await prisma.todo.create({
       data: {
         title: inputData.title,

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -110,12 +110,16 @@ export class TodoRepository implements ITodoRepository {
   }
 
   async delete(id: number) {
+    if (id < 1 || !Number.isInteger(id)) {
+      throw new InvalidError("IDは1以上の整数のみ。");
+    }
+
     const deleteItem = await prisma.todo.findUnique({
       where: { id: id },
     });
 
     if (!deleteItem) {
-      throw new Error("存在しないIDを指定しました。");
+      throw new NotFoundError("存在しないIDを指定しました。");
     }
 
     const responseDeleteItem = prisma.todo.delete({

--- a/src/routers/todos.ts
+++ b/src/routers/todos.ts
@@ -35,8 +35,8 @@ router
   .put((req, res, next) => {
     todoUpdateController.update(req, res, next);
   })
-  .delete((req, res) => {
-    todoDeleteController.delete(req, res);
+  .delete((req, res, next) => {
+    todoDeleteController.delete(req, res, next);
   });
 
 export default router;


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

修正内容は、
他コントローラーの
モックを利用したユニットテストと
同様です。

![スクリーンショット 2024-09-03 160735](https://github.com/user-attachments/assets/4750d41d-5651-46b9-8fea-065be010137a)
不正なIDでのリクエストはエラーになるよう、
find、updateと同様にガード節を追加しました。

![スクリーンショット 2024-09-03 161027](https://github.com/user-attachments/assets/1788856c-5655-4cda-b0c9-e324a23a33d6)
エラー内容に応じて、
ミドルウェアでエラーを処理するよう
next関数のパラメーターにエラーオブジェクトを
渡すよう修正しました。

ユニットテスト、インテグレーションテスト共に、
追加したエラーオブジェクトに応じた内容のテストを
追加しました。

よろしくお願いします。

