### PR TITLE
【validation機能の追加】～CRUD(前々回のプルリクで作成したcreate以外)処理のミドルウェア実装～

### DIFF
--- a/src/__test__/app/api/todos/DeleteTodoController.spec.ts
+++ b/src/__test__/app/api/todos/DeleteTodoController.spec.ts
@@ -19,12 +19,12 @@ describe("【APIテスト】 Todo一件の削除", () => {
         });
       }
     });
-    it("deleteメソッド実行前、DBに格納されているTodoは3件である。", async () => {
+    it("【deleteメソッド実行前】DBに格納されているTodoは3件である。", async () => {
       const dbOldData = await prisma.todo.findMany({});
 
       expect(dbOldData.length).toEqual(3);
     });
-    it("id:1のデータ削除", async () => {
+    it("【id:1のデータ削除】", async () => {
       const response = await requestAPI({
         method: "delete",
         endPoint: "/api/todos/1",
@@ -36,7 +36,7 @@ describe("【APIテスト】 Todo一件の削除", () => {
       expect(title).toEqual("ダミータイトル1");
       expect(body).toEqual("ダミーボディ1");
     });
-    it("deleteメソッド実行後、3件のTodoから1件のデータが削除されている。", async () => {
+    it("【deleteメソッド実行後】3件のTodoから1件のデータが削除されている。", async () => {
       await requestAPI({
         method: "delete",
         endPoint: "/api/todos/1",

--- a/src/__test__/app/api/todos/GetTodoController.spec.ts
+++ b/src/__test__/app/api/todos/GetTodoController.spec.ts
@@ -19,7 +19,7 @@ describe("【APIテスト】 Todo1件の取得", () => {
         });
       }
     });
-    it("id:1のデータ取得", async () => {
+    it("【id:1のデータ取得】", async () => {
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos/1",
@@ -32,7 +32,7 @@ describe("【APIテスト】 Todo1件の取得", () => {
       expect(title).toEqual("ダミータイトル1");
       expect(body).toEqual("ダミーボディ1");
     });
-    it("id:2のデータ取得", async () => {
+    it("【id:2のデータ取得】", async () => {
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos/2",

--- a/src/__test__/app/api/todos/GetTodosController.spec.ts
+++ b/src/__test__/app/api/todos/GetTodosController.spec.ts
@@ -9,7 +9,7 @@ import type { TodoResponseType } from "../../../helper/types/testTypes";
 const prisma = new PrismaClient();
 
 describe("【APIテスト】 Todo一覧取得", () => {
-  describe("DBにデータあり", () => {
+  describe("【DBにデータあり】", () => {
     beforeEach(async () => {
       for (let i = 1; i <= 20; i++) {
         await prisma.todo.create({
@@ -145,7 +145,7 @@ describe("【APIテスト】 Todo一覧取得", () => {
       ]);
     });
   });
-  describe("DBにデータなし", () => {
+  describe("【DBにデータなし】", () => {
     it("データがない状態でTodo一覧を取得する(空配列が返る)", async () => {
       const response = await requestAPI({
         method: "get",

--- a/src/__test__/app/api/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/app/api/todos/UpdateTodoController.spec.ts
@@ -19,8 +19,8 @@ describe("【APIテスト】Todo一件の更新", () => {
         });
       }
     });
-    it("id:1のデータ更新(タイトルのみ)", async () => {
-      const requestTitleData = {
+    it("【id:1のデータ更新】タイトルのみ", async () => {
+      const request = {
         title: "変更後のタイトル",
       };
 
@@ -28,7 +28,7 @@ describe("【APIテスト】Todo一件の更新", () => {
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.OK,
-      }).send(requestTitleData);
+      }).send(request);
 
       const { id, title, body } = response.body;
 
@@ -36,8 +36,8 @@ describe("【APIテスト】Todo一件の更新", () => {
       expect(title).toEqual("変更後のタイトル");
       expect(body).toEqual("ダミーボディ1");
     });
-    it("id:1のデータ更新(ボディのみ)", async () => {
-      const requestBodyData = {
+    it("【id:1のデータ更新】ボディのみ", async () => {
+      const request = {
         body: "変更後のボディ",
       };
 
@@ -45,7 +45,7 @@ describe("【APIテスト】Todo一件の更新", () => {
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.OK,
-      }).send(requestBodyData);
+      }).send(request);
 
       const { id, title, body } = response.body;
 
@@ -53,8 +53,8 @@ describe("【APIテスト】Todo一件の更新", () => {
       expect(title).toEqual("ダミータイトル1");
       expect(body).toEqual("変更後のボディ");
     });
-    it("id:2のデータ更新(タイトルとボディ)", async () => {
-      const requestBothData = {
+    it("【id:2のデータ更新】タイトルとボディ", async () => {
+      const request = {
         title: "変更後のタイトル",
         body: "変更後のボディ",
       };
@@ -63,7 +63,7 @@ describe("【APIテスト】Todo一件の更新", () => {
         method: "put",
         endPoint: "/api/todos/2",
         statusCode: StatusCodes.OK,
-      }).send(requestBothData);
+      }).send(request);
 
       const { id, title, body } = response.body;
 
@@ -74,13 +74,11 @@ describe("【APIテスト】Todo一件の更新", () => {
   });
   describe("【異常パターン】", () => {
     it("タイトルに不適切な値(文字列ではない値)が入力された場合、リクエストはエラーになる", async () => {
-      const badInputCharacter = 123;
-
       const response = await requestAPI({
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.BAD_REQUEST,
-      }).send({ title: badInputCharacter });
+      }).send({ title: 123 });
 
       expect(response.body).toEqual({
         message: "入力内容が不適切(文字列のみ)です。",
@@ -88,13 +86,11 @@ describe("【APIテスト】Todo一件の更新", () => {
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
     });
     it("ボディに不適切な値(文字列ではない値)が入力された場合、リクエストはエラーになる", async () => {
-      const badInputCharacter = 123;
-
       const response = await requestAPI({
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.BAD_REQUEST,
-      }).send({ body: badInputCharacter });
+      }).send({ body: 123 });
 
       expect(response.body).toEqual({
         message: "入力内容が不適切(文字列のみ)です。",

--- a/src/__test__/controllers/todos/CreateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/CreateTodoController.spec.ts
@@ -50,7 +50,7 @@ describe("【ユニットテスト】Todo1件の新規作成", () => {
     });
   });
   describe("【異常パターン】", () => {
-    it("タイトルが未入力の場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
+    it("【タイトルが未入力の場合】next関数(パラメーターがInvalidError)を実行する。", async () => {
       const req = createMockRequest({
         body: {
           title: "",
@@ -68,7 +68,7 @@ describe("【ユニットテスト】Todo1件の新規作成", () => {
 
       expect(next).toHaveBeenCalledWith(expect.any(InvalidError));
     });
-    it("ボディが未入力の場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
+    it("【ボディが未入力の場合】next関数(パラメーターがInvalidError)を実行する。", async () => {
       const req = createMockRequest({
         body: {
           title: "ダミータイトル",

--- a/src/__test__/controllers/todos/GetTodosController.spec.ts
+++ b/src/__test__/controllers/todos/GetTodosController.spec.ts
@@ -13,8 +13,8 @@ describe("【ユニットテスト】 Todo一覧取得", () => {
     repository = new MockRepository();
     controller = new GetTodosController(repository);
   });
-  describe("DBにデータなし", () => {
-    it("空配列が返る(jsonとstatus(ok=200)が返る)", async () => {
+  describe("【DBにデータなし】", () => {
+    it("空配列(jsonとstatus(ok=200))が返る)", async () => {
       const req = createMockRequest({ query: {} });
       const res = createMockResponse();
       const next = jest.fn();
@@ -27,8 +27,8 @@ describe("【ユニットテスト】 Todo一覧取得", () => {
       expect(res.json).toHaveBeenCalledWith([]);
     });
   });
-  describe("DBにデータあり", () => {
-    it("Todo一覧の取得(jsonとstatus(ok=200)が返る)", async () => {
+  describe("【DBにデータあり】", () => {
+    it("Todo一覧(jsonとstatus(ok=200)が返る)", async () => {
       const req = createMockRequest({ query: {} });
       const res = createMockResponse();
       const next = jest.fn();
@@ -85,7 +85,7 @@ describe("【ユニットテスト】 Todo一覧取得", () => {
       ]);
     });
   });
-  describe("パラメーターの指定有り・無しの場合", () => {
+  describe("【パラメーターの指定有り・無しの場合】", () => {
     it("listメソッドのパラメーターが【page=undefined,count=undefined】で呼び出される", async () => {
       const req = createMockRequest({ query: {} });
       const res = createMockResponse();
@@ -130,7 +130,7 @@ describe("【ユニットテスト】 Todo一覧取得", () => {
     });
   });
   describe("【異常パターン】", () => {
-    it("パラメーターに指定した値が不正(page=整数の1以上でない値)の場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
+    it("【パラメーターに指定した値が不正(page=整数の1以上でない値)の場合】next関数(パラメーターがInvalidError)を実行する。", async () => {
       const req = createMockRequest({ query: { page: 0 } });
       const res = createMockResponse();
       const next = jest.fn();
@@ -143,7 +143,7 @@ describe("【ユニットテスト】 Todo一覧取得", () => {
 
       expect(next).toHaveBeenCalledWith(expect.any(InvalidError));
     });
-    it("パラメーターに指定した値が不正(count=整数の1以上でない値)の場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
+    it("【パラメーターに指定した値が不正(count=整数の1以上でない値)の場合】next関数(パラメーターがInvalidError)を実行する。", async () => {
       const req = createMockRequest({ query: { count: 0 } });
       const res = createMockResponse();
       const next = jest.fn();

--- a/src/__test__/controllers/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/UpdateTodoController.spec.ts
@@ -113,7 +113,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
       });
     });
     describe("【異常パターン】", () => {
-      it("タイトルに不適切な値(文字列ではない値)が入力された場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
+      it("【タイトルに不適切な値(文字列ではない値)が入力された場合】next関数(パラメーターがInvalidError)を実行する。", async () => {
         const req = createMockRequest({
           params: { id: "1" },
           body: { title: 111, body: "変更後のボディ" },
@@ -129,7 +129,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
 
         expect(next).toHaveBeenCalledWith(expect.any(InvalidError));
       });
-      it("ボディに不適切な値(文字列ではない値)が入力された場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
+      it("【ボディに不適切な値(文字列ではない値)が入力された場合】next関数(パラメーターがInvalidError)を実行する。", async () => {
         const req = createMockRequest({
           params: { id: "1" },
           body: { title: "変更後のタイトル", body: 222 },

--- a/src/__test__/middlewares/validateHandler.spec.ts
+++ b/src/__test__/middlewares/validateHandler.spec.ts
@@ -4,6 +4,9 @@ import { type AnyZodObject, ZodError } from "zod";
 import { InvalidError } from "../../errors/InvalidError";
 import { validator } from "../../middlewares/validateHandler";
 import { createTodoSchema } from "../../schemas/createTodoSchema";
+import { getTodosSchema } from "../../schemas/getTodosSchema ";
+import { requestIdSchema } from "../../schemas/requestIdSchema";
+import { updateTodoSchema } from "../../schemas/updateTodoSchema";
 import { createMockRequest } from "../helper/mocks/request";
 import { createMockResponse } from "../helper/mocks/response";
 
@@ -17,18 +20,57 @@ describe("【ユニットテスト】ミドルウェアのバリデーション�
     res = createMockResponse();
     next = jest.fn();
   });
-  it("【成功パターン】バリデーションが成功すると、next関数が呼び出される。", () => {
-    req = createMockRequest({
-      body: { title: "ダミータイトル", body: "ダミーボディ" },
+  describe("【成功パターン】", () => {
+    it("バリデーションが成功(createTodoSchemaの場合)すると、next関数が呼び出される。", () => {
+      req = createMockRequest({
+        body: { title: "ダミータイトル", body: "ダミーボディ" },
+      });
+
+      const validatedFunc = validator(createTodoSchema, "body");
+      validatedFunc(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
     });
+    it("バリデーションが成功(requestIdSchemaの場合)すると、next関数が呼び出される。", () => {
+      req = createMockRequest({
+        params: { id: "1" },
+      });
 
-    const validateFunc = validator(createTodoSchema);
-    validateFunc(req, res, next);
+      const validatedFunc = validator(requestIdSchema, "params");
+      validatedFunc(req, res, next);
 
-    expect(next).toHaveBeenCalledWith();
+      expect(next).toHaveBeenCalledWith();
+    });
+    it("バリデーションが成功(getTodosSchemaの場合)すると、next関数が呼び出される。", () => {
+      req = createMockRequest({
+        query: { page: "1", count: "5" },
+      });
+
+      const validatedFunc = validator(getTodosSchema, "query");
+      validatedFunc(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+    it("バリデーションが成功(updateTodoSchemaの場合)すると、next関数が呼び出される。", () => {
+      req = createMockRequest({
+        params: { id: "1" },
+        body: {
+          title: "変更後のタイトル",
+          body: "変更後のボディ",
+        },
+      });
+
+      const validatedId = validator(updateTodoSchema, "params");
+      const validatedTitleBody = validator(updateTodoSchema, "body");
+
+      validatedId(req, res, next);
+      validatedTitleBody(req, res, next);
+
+      expect(next).toHaveBeenCalledWith();
+    });
   });
   describe("【異常パターン】", () => {
-    it("バリデーションに失敗すると、next関数がパラメーターにInvalidError(ZodErrorのエラー情報をInvalidErrorに変換)で呼び出される。", () => {
+    it("バリデーションに失敗(createTodoSchemaの場合)すると、next関数がパラメーターにInvalidError(ZodErrorのエラー情報をInvalidErrorに変換)で呼び出される。", () => {
       const mockCreateTodoSchema: AnyZodObject = {
         parse: jest.fn(() => {
           throw new ZodError([
@@ -54,13 +96,117 @@ describe("【ユニットテスト】ミドルウェアのバリデーション�
         body: { title: "", body: "" },
       });
 
-      const validateFunc = validator(mockCreateTodoSchema);
-      validateFunc(req, res, next);
+      const validatedFunc = validator(mockCreateTodoSchema, "body");
+      validatedFunc(req, res, next);
 
       expect(next).toHaveBeenCalledWith(expect.any(InvalidError));
       expect(next).toHaveBeenCalledWith(
         expect.objectContaining({
           message: "titleの内容は必須です。, bodyの内容は必須です。",
+        }),
+      );
+    });
+    it("バリデーションに失敗(requestIdSchemaの場合)すると、next関数がパラメーターにInvalidError(ZodErrorのエラー情報をInvalidErrorに変換)で呼び出される。", () => {
+      const mockRequestIdSchema: AnyZodObject = {
+        parse: jest.fn(() => {
+          throw new ZodError([
+            {
+              code: "invalid_type",
+              expected: "string",
+              received: "undefined",
+              path: ["id"],
+              message: "IDは1以上の整数のみ。",
+            },
+          ]);
+        }),
+      } as Partial<AnyZodObject> as AnyZodObject;
+
+      req = createMockRequest({
+        params: { id: "0" },
+      });
+
+      const validatedFunc = validator(mockRequestIdSchema, "params");
+      validatedFunc(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(InvalidError));
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "IDは1以上の整数のみ。",
+        }),
+      );
+    });
+    it("バリデーションに失敗(getTodosSchemaの場合)すると、next関数がパラメーターにInvalidError(ZodErrorのエラー情報をInvalidErrorに変換)で呼び出される。", () => {
+      const mockGetTodosSchema: AnyZodObject = {
+        parse: jest.fn(() => {
+          throw new ZodError([
+            {
+              code: "invalid_type",
+              expected: "string",
+              received: "undefined",
+              path: ["page"],
+              message: "pageは1以上の整数のみ。",
+            },
+            {
+              code: "invalid_type",
+              expected: "string",
+              received: "undefined",
+              path: ["count"],
+              message: "countは1以上の整数のみ。",
+            },
+          ]);
+        }),
+      } as Partial<AnyZodObject> as AnyZodObject;
+
+      req = createMockRequest({
+        query: { page: "0", count: "0" },
+      });
+
+      const validatedFunc = validator(mockGetTodosSchema, "query");
+      validatedFunc(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(InvalidError));
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "pageは1以上の整数のみ。, countは1以上の整数のみ。",
+        }),
+      );
+    });
+    it("バリデーションに失敗(updateTodoSchemaの場合)すると、next関数がパラメーターにInvalidError(ZodErrorのエラー情報をInvalidErrorに変換)で呼び出される。", () => {
+      const mockUpdateTodoSchema: AnyZodObject = {
+        parse: jest.fn(() => {
+          throw new ZodError([
+            {
+              code: "invalid_type",
+              expected: "string",
+              received: "undefined",
+              path: ["title"],
+              message: "入力内容が不適切(文字列のみ)です。",
+            },
+            {
+              code: "invalid_type",
+              expected: "string",
+              received: "undefined",
+              path: ["body"],
+              message: "入力内容が不適切(文字列のみ)です。",
+            },
+          ]);
+        }),
+      } as Partial<AnyZodObject> as AnyZodObject;
+
+      req = createMockRequest({
+        params: { id: "1" },
+        body: { title: 0, body: 0 },
+      });
+
+      const validatedFunc = validator(mockUpdateTodoSchema, "body");
+
+      validatedFunc(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(InvalidError));
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            "入力内容が不適切(文字列のみ)です。, 入力内容が不適切(文字列のみ)です。",
         }),
       );
     });
@@ -75,8 +221,8 @@ describe("【ユニットテスト】ミドルウェアのバリデーション�
         body: { title: "ダミータイトル", body: "ダミーボディ" },
       });
 
-      const validateFunc = validator(mockCreateTodoSchema);
-      validateFunc(req, res, next);
+      const validatedFunc = validator(mockCreateTodoSchema, "body");
+      validatedFunc(req, res, next);
 
       expect(next).toHaveBeenCalledWith(expect.any(Error));
       expect(next).toHaveBeenCalledWith(

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -151,35 +151,6 @@ describe("【TodoRepositoryのテスト】", () => {
     });
   });
   describe("【異常パターン】", () => {
-    it("【saveメソッドを実行時】タイトル or ボディに値がない場合、エラーオブジェクトが返る。", () => {
-      const repository = new TodoRepository();
-
-      expect(async () => {
-        await repository.save({ title: "", body: "ダミーボディ" });
-      }).rejects.toThrow("titleの内容は必須です");
-
-      expect(async () => {
-        await repository.save({ title: "ダミータイトル", body: "" });
-      }).rejects.toThrow("bodyの内容は必須です");
-    });
-    it("【listメソッド実行時】クエリーパラメーターが不正な場合、エラーオブジェクトが返る。", () => {
-      const repository = new TodoRepository();
-
-      expect(async () => {
-        await repository.list({ page: 0 });
-      }).rejects.toThrow("pageは1以上の整数のみ");
-
-      expect(async () => {
-        await repository.list({ count: 0 });
-      }).rejects.toThrow("countは1以上の整数のみ");
-    });
-    it("【findメソッド実行時】指定したIDが不正な場合、エラーオブジェクトが返る。", () => {
-      const repository = new TodoRepository();
-
-      expect(async () => {
-        await repository.find(0);
-      }).rejects.toThrow("IDは1以上の整数のみ。");
-    });
     it("【findメソッド実行時】指定したIDのデータがない場合、エラーオブジェクトが返る。", () => {
       const repository = new TodoRepository();
 
@@ -187,7 +158,7 @@ describe("【TodoRepositoryのテスト】", () => {
         await repository.find(999);
       }).rejects.toThrow("存在しないIDを指定しました。");
     });
-    it("【updateメソッド実行時】不正なIDを指定した場合、エラーオブジェクトが返る。", () => {
+    it("【updateメソッド実行時】指定したIDのデータがない場合、エラーオブジェクトが返る。", () => {
       const repository = new TodoRepository();
 
       expect(async () => {
@@ -198,7 +169,7 @@ describe("【TodoRepositoryのテスト】", () => {
         });
       }).rejects.toThrow("存在しないIDを指定しました。");
     });
-    it("【deleteメソッド実行時】不正なIDを指定した場合、エラーオブジェクトが返る。", () => {
+    it("【deleteメソッド実行時】指定したIDのデータがない場合、エラーオブジェクトが返る。", () => {
       const repository = new TodoRepository();
 
       expect(async () => {

--- a/src/middlewares/validateHandler.ts
+++ b/src/middlewares/validateHandler.ts
@@ -3,10 +3,13 @@ import { ZodError, type z } from "zod";
 
 import { InvalidError } from "../errors/InvalidError";
 
-export function validator(schema: z.AnyZodObject) {
+export function validator(
+  schema: z.AnyZodObject,
+  target: "body" | "params" | "query",
+) {
   return (req: Request, res: Response, next: NextFunction) => {
     try {
-      schema.parse(req.body);
+      schema.parse(req[target]);
       next();
     } catch (error) {
       if (error instanceof ZodError) {

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -3,7 +3,6 @@ import type { Todo } from "@prisma/client";
 
 import type { ITodoRepository } from "./ITodoRepository";
 
-import { InvalidError } from "../errors/InvalidError";
 import { NotFoundError } from "../errors/NotFoundError";
 import type { TodoInput } from "../types/TodoRequest.type";
 import type { TodoUpdatedInput } from "../types/TodoRequest.type";
@@ -40,13 +39,6 @@ export class TodoRepository implements ITodoRepository {
       count: DEFAULT_COUNT,
     },
   ) {
-    if (page < 1 || !Number.isInteger(page)) {
-      throw new InvalidError("pageは1以上の整数のみ。");
-    }
-    if (count < 1 || !Number.isInteger(count)) {
-      throw new InvalidError("countは1以上の整数のみ。");
-    }
-
     const offset = (page - 1) * count;
     const todos = await prisma.todo.findMany({
       skip: offset,
@@ -57,10 +49,6 @@ export class TodoRepository implements ITodoRepository {
   }
 
   async find(id: number) {
-    if (id < 1 || !Number.isInteger(id)) {
-      throw new InvalidError("IDは1以上の整数のみ。");
-    }
-
     const todoItem = await prisma.todo.findUnique({
       where: {
         id: id,
@@ -75,13 +63,6 @@ export class TodoRepository implements ITodoRepository {
   }
 
   async update({ id, title, body }: TodoUpdatedInput) {
-    if (
-      (title && typeof title !== "string") ||
-      (body && typeof body !== "string")
-    ) {
-      throw new InvalidError("入力内容が不適切(文字列のみ)です。");
-    }
-
     const updateItem = await prisma.todo.findUnique({
       where: { id: id },
     });
@@ -102,10 +83,6 @@ export class TodoRepository implements ITodoRepository {
   }
 
   async delete(id: number) {
-    if (id < 1 || !Number.isInteger(id)) {
-      throw new InvalidError("IDは1以上の整数のみ。");
-    }
-
     const deleteItem = await prisma.todo.findUnique({
       where: { id: id },
     });

--- a/src/routers/todos.ts
+++ b/src/routers/todos.ts
@@ -8,6 +8,9 @@ import { UpdateTodoController } from "../controllers/todos/UpdateTodoController"
 import { validator } from "../middlewares/validateHandler";
 import { TodoRepository } from "../repositories/TodoRepository";
 import { createTodoSchema } from "../schemas/createTodoSchema";
+import { getTodosSchema } from "../schemas/getTodosSchema ";
+import { requestIdSchema } from "../schemas/requestIdSchema";
+import { updateTodoSchema } from "../schemas/updateTodoSchema";
 
 const router = express.Router();
 
@@ -20,22 +23,26 @@ const todoDeleteController = new DeleteTodoController(todoRepository);
 
 router
   .route("/")
-  .post(validator(createTodoSchema), (req, res, next) => {
+  .post(validator(createTodoSchema, "body"), (req, res, next) => {
     todoCreateController.create(req, res, next);
   })
-  .get((req, res, next) => {
+  .get(validator(getTodosSchema, "query"), (req, res, next) => {
     todosGetController.list(req, res, next);
   });
 
 router
   .route("/:id")
-  .get((req, res, next) => {
+  .get(validator(requestIdSchema, "params"), (req, res, next) => {
     todoGetController.find(req, res, next);
   })
-  .put((req, res, next) => {
-    todoUpdateController.update(req, res, next);
-  })
-  .delete((req, res, next) => {
+  .put(
+    validator(requestIdSchema, "params"),
+    validator(updateTodoSchema, "body"),
+    (req, res, next) => {
+      todoUpdateController.update(req, res, next);
+    },
+  )
+  .delete(validator(requestIdSchema, "params"), (req, res, next) => {
     todoDeleteController.delete(req, res, next);
   });
 

--- a/src/schemas/getTodosSchema .ts
+++ b/src/schemas/getTodosSchema .ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+export const getTodosSchema = z.object({
+  page: z
+    .string()
+    .refine(
+      (query) => {
+        return Number(query) > 0;
+      },
+      {
+        message: "pageは1以上の整数のみ。",
+      },
+    )
+    .optional(),
+  count: z
+    .string()
+    .refine(
+      (query) => {
+        return Number(query) > 0;
+      },
+      {
+        message: "countは1以上の整数のみ。",
+      },
+    )
+    .optional(),
+});
+
+// {
+//   invalid_type_error: "入力内容が不適切(文字列のみ)です。",
+// }
+// export const getTodosSchema = z.object({
+//   page: z.number().int().nonpositive(),
+//   count: z.number().int().nonpositive(),
+// });

--- a/src/schemas/requestIdSchema.ts
+++ b/src/schemas/requestIdSchema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const requestIdSchema = z.object({
+  id: z.string().refine(
+    (id) => {
+      return Number(id) > 0;
+    },
+    {
+      message: "IDは1以上の整数のみ。",
+    },
+  ),
+});

--- a/src/schemas/updateTodoSchema.ts
+++ b/src/schemas/updateTodoSchema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const updateTodoSchema = z.object({
+  title: z
+    .string({
+      invalid_type_error: "入力内容が不適切(文字列のみ)です。",
+    })
+    .optional(),
+  body: z
+    .string({
+      invalid_type_error: "入力内容が不適切(文字列のみ)です。",
+    })
+    .optional(),
+});


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

validation処理のスキーマは以下にしました。
![スクリーンショット 2024-09-05 182741](https://github.com/user-attachments/assets/99887647-b9bc-4596-b98b-b9bcd325d1c0)
delete、find以外はコントローラーと
関連付けて命名しました。

delete、findは、
idの事前validation処理が重複するので、
requestIdSchemaとしました。

リクエスト・ボディの値が文字列なので、
1以上の整数を検証していたID値とクエリパラメータは、
refineを使用しました。
![スクリーンショット 2024-09-05 183953](https://github.com/user-attachments/assets/a6bb2ba9-9f63-47fb-ac01-565f1da79a92)

ミドルウェアでの事前処理が
出来ないエラーハンドリング(NotFoundError)は、
そのままにしています。

リポジトリとAPIテストの不要なエラーハンドリングとテストは
削除し、統一性をもたらすようリファクタリングをしました。

よろしくお願いします。


