### PR TITLE
【validationテストのリファクタリング】～GetTodosスキーマの挙動テスト～

### DIFF
--- a/src/__test__/app/api/todos/GetTodosController.spec.ts
+++ b/src/__test__/app/api/todos/GetTodosController.spec.ts
@@ -9,18 +9,18 @@ import type { TodoResponseType } from "../../../helper/types/testTypes";
 const prisma = new PrismaClient();
 
 describe("【APIテスト】 Todo一覧取得", () => {
-  describe("DBにデータあり", () => {
+  describe("【DBにデータあり】", () => {
     beforeEach(async () => {
       for (let i = 1; i <= 20; i++) {
         await prisma.todo.create({
           data: {
-            title: "ダミータイトル" + i,
-            body: "ダミーボディ" + i,
+            title: `ダミータイトル${i}`,
+            body: `ダミーボディ${i}`,
           },
         });
       }
     });
-    it("【パラメーターの指定なし】先頭から10件のTodoを取得できる)", async () => {
+    it("【パラメーターの指定なし】先頭から10件のTodoを取得できる。", async () => {
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos",
@@ -58,7 +58,7 @@ describe("【APIテスト】 Todo一覧取得", () => {
         "ダミーボディ10",
       ]);
     });
-    it("【page=2,count=5】6件目から5件のTodoを取得できる)", async () => {
+    it("【page=2,count=5】6件目から5件のTodoを取得できる。", async () => {
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos?page=2&count=5",
@@ -84,7 +84,7 @@ describe("【APIテスト】 Todo一覧取得", () => {
         "ダミーボディ10",
       ]);
     });
-    it("【page=2】11件目から10件のTodoを取得できる)", async () => {
+    it("【page=2】11件目から10件のTodoを取得できる。", async () => {
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos?page=2",
@@ -122,7 +122,7 @@ describe("【APIテスト】 Todo一覧取得", () => {
         "ダミーボディ20",
       ]);
     });
-    it("【count=3】先頭から3件のTodoを取得できる)", async () => {
+    it("【count=3】先頭から3件のTodoを取得できる。", async () => {
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos?count=3",
@@ -145,8 +145,8 @@ describe("【APIテスト】 Todo一覧取得", () => {
       ]);
     });
   });
-  describe("DBにデータなし", () => {
-    it("データがない状態でTodo一覧を取得する(空配列が返る)", async () => {
+  describe("【DBにデータなし】", () => {
+    it("【空配列が返る】データがない状態でのTodo一覧取得", async () => {
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos",
@@ -159,7 +159,7 @@ describe("【APIテスト】 Todo一覧取得", () => {
     });
   });
   describe("【異常パターン】", () => {
-    it("パラメーターに指定した値が不正(page=整数の1以上でない値)の場合、エラーになる", async () => {
+    it("【パラメーターに指定した値が不正(page=整数の1以上でない値)の場合】getTodosSchemaに基づくInvalidErrorのテスト。", async () => {
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos?page=0",
@@ -169,7 +169,7 @@ describe("【APIテスト】 Todo一覧取得", () => {
       expect(response.body).toEqual({ message: "pageは1以上の整数のみ。" });
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
     });
-    it("パラメーターに指定した値が不正(count=整数の1以上でない値)の場合、エラーになる", async () => {
+    it("【パラメーターに指定した値が不正(count=整数の1以上でない値)の場合】getTodosSchemaに基づくInvalidErrorのテスト。", async () => {
       const response = await requestAPI({
         method: "get",
         endPoint: "/api/todos?count=0",

--- a/src/__test__/schemas/todos/getTodosSchema.spec.ts
+++ b/src/__test__/schemas/todos/getTodosSchema.spec.ts
@@ -1,0 +1,49 @@
+import { ZodError } from "zod";
+
+import { getTodosSchema } from "../../../schemas/todos/getTodosSchema";
+
+describe("【ユニットテスト】getTodosSchemaの挙動テスト", () => {
+  describe("【成功パターン】", () => {
+    it("【バリデーションに成功した場合】例外が発生しない。", () => {
+      const data = {
+        query: { page: "1", count: "5" },
+      };
+
+      const result = getTodosSchema.parse(data.query);
+
+      expect(result).toEqual(data.query);
+    });
+  });
+  describe("【異常パターン】", () => {
+    it("【pageの入力値が不正(page=整数の1以上でない値)な場合】例外が発生する。", () => {
+      const data = {
+        query: { page: "0" },
+      };
+
+      expect(() => getTodosSchema.parse(data.query)).toThrow(
+        new ZodError([
+          {
+            code: "custom",
+            message: "pageは1以上の整数のみ。",
+            path: ["page"],
+          },
+        ]),
+      );
+    });
+    it("【countの入力値が不正(count=整数の1以上でない値)な場合】例外が発生する。", () => {
+      const data = {
+        query: { count: "0" },
+      };
+
+      expect(() => getTodosSchema.parse(data.query)).toThrow(
+        new ZodError([
+          {
+            code: "custom",
+            message: "countは1以上の整数のみ。",
+            path: ["count"],
+          },
+        ]),
+      );
+    });
+  });
+});

--- a/src/__test__/schemas/todos/getTodosSchema.spec.ts
+++ b/src/__test__/schemas/todos/getTodosSchema.spec.ts
@@ -5,42 +5,35 @@ import { getTodosSchema } from "../../../schemas/todos/getTodosSchema";
 describe("【ユニットテスト】getTodosSchemaの挙動テスト", () => {
   describe("【成功パターン】", () => {
     it("【バリデーションに成功した場合】例外が発生しない。", () => {
-      const data = {
-        query: { page: "1", count: "5" },
-      };
+      const data = { query: { page: "1", count: "5" } };
+      const result = getTodosSchema.parse(data);
 
-      const result = getTodosSchema.parse(data.query);
-
-      expect(result).toEqual(data.query);
+      expect(result).toEqual(data);
     });
   });
   describe("【異常パターン】", () => {
     it("【pageの入力値が不正(page=整数の1以上でない値)な場合】例外が発生する。", () => {
-      const data = {
-        query: { page: "0" },
-      };
+      const data = { query: { page: "0" } };
 
-      expect(() => getTodosSchema.parse(data.query)).toThrow(
+      expect(() => getTodosSchema.parse(data)).toThrow(
         new ZodError([
           {
             code: "custom",
             message: "pageは1以上の整数のみ。",
-            path: ["page"],
+            path: ["query", "page"],
           },
         ]),
       );
     });
     it("【countの入力値が不正(count=整数の1以上でない値)な場合】例外が発生する。", () => {
-      const data = {
-        query: { count: "0" },
-      };
+      const data = { query: { count: "0" } };
 
-      expect(() => getTodosSchema.parse(data.query)).toThrow(
+      expect(() => getTodosSchema.parse(data)).toThrow(
         new ZodError([
           {
             code: "custom",
             message: "countは1以上の整数のみ。",
-            path: ["count"],
+            path: ["query", "count"],
           },
         ]),
       );

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -40,14 +40,8 @@ export class TodoRepository implements ITodoRepository {
       count: DEFAULT_COUNT,
     },
   ) {
-    if (page < 1 || !Number.isInteger(page)) {
-      throw new InvalidError("pageは1以上の整数のみ。");
-    }
-    if (count < 1 || !Number.isInteger(count)) {
-      throw new InvalidError("countは1以上の整数のみ。");
-    }
-
     const offset = (page - 1) * count;
+
     const todos = await prisma.todo.findMany({
       skip: offset,
       take: count,

--- a/src/routers/todos.ts
+++ b/src/routers/todos.ts
@@ -8,6 +8,7 @@ import { UpdateTodoController } from "../controllers/todos/UpdateTodoController"
 import { validator } from "../middlewares/validateHandler";
 import { TodoRepository } from "../repositories/TodoRepository";
 import { createTodoSchema } from "../schemas/todos/createTodoSchema";
+import { getTodosSchema } from "../schemas/todos/getTodosSchema";
 
 const router = express.Router();
 
@@ -23,7 +24,7 @@ router
   .post(validator(createTodoSchema), (req, res, next) => {
     todoCreateController.create(req, res, next);
   })
-  .get((req, res, next) => {
+  .get(validator(getTodosSchema), (req, res, next) => {
     todosGetController.list(req, res, next);
   });
 

--- a/src/schemas/todos/getTodosSchema.ts
+++ b/src/schemas/todos/getTodosSchema.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const getTodosSchema = z.object({
+  query: z.object({
+    page: z
+      .string()
+      .refine(
+        (query) => {
+          return Number(query) > 0;
+        },
+        {
+          message: "pageは1以上の整数のみ。",
+        },
+      )
+      .optional(),
+    count: z
+      .string()
+      .refine(
+        (query) => {
+          return Number(query) > 0;
+        },
+        {
+          message: "countは1以上の整数のみ。",
+        },
+      )
+      .optional(),
+  }),
+});


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

getTodosSchemaは、
以前作成したものを
そのまま使用しました。
![スクリーンショット 2024-09-10 131947](https://github.com/user-attachments/assets/a3e6134d-ceb5-47dd-85d7-97bb28a6fcec)

リポジトリの
ガード節は削除し、
gettodosのルーターに
バリデーションを追加しました。
![スクリーンショット 2024-09-10 132048](https://github.com/user-attachments/assets/940b427f-70b5-4e60-950d-6d375faf7e6c)


getTodosSchemaのユニットテストは、
成功パターン・異常パターンを用意し、
getTodosSchemaでparseメソッドを実行し、
例外が発生するか否かを確認できるよう、
前回のプルリクと同様に実装しました。

異常パターンは、
refineでpageとcount値が、
1以下のものを例外として処理するかを
確認できるよう実装しました。

よろしくお願いします。


