### PR TITLE
【validationテストのリファクタリング】～UpdateTodoスキーマの挙動テスト～ 

### DIFF
--- a/src/__test__/app/api/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/app/api/todos/UpdateTodoController.spec.ts
@@ -19,8 +19,8 @@ describe("【APIテスト】Todo一件の更新", () => {
         });
       }
     });
-    it("id:1のデータ更新(タイトルのみ)", async () => {
-      const requestTitleData = {
+    it("【id:1のデータ更新】タイトルのみ", async () => {
+      const data = {
         title: "変更後のタイトル",
       };
 
@@ -28,7 +28,7 @@ describe("【APIテスト】Todo一件の更新", () => {
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.OK,
-      }).send(requestTitleData);
+      }).send(data);
 
       const { id, title, body } = response.body;
 
@@ -36,8 +36,8 @@ describe("【APIテスト】Todo一件の更新", () => {
       expect(title).toEqual("変更後のタイトル");
       expect(body).toEqual("ダミーボディ1");
     });
-    it("id:1のデータ更新(ボディのみ)", async () => {
-      const requestBodyData = {
+    it("【id:1のデータ更新】ボディのみ", async () => {
+      const data = {
         body: "変更後のボディ",
       };
 
@@ -45,7 +45,7 @@ describe("【APIテスト】Todo一件の更新", () => {
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.OK,
-      }).send(requestBodyData);
+      }).send(data);
 
       const { id, title, body } = response.body;
 
@@ -53,8 +53,8 @@ describe("【APIテスト】Todo一件の更新", () => {
       expect(title).toEqual("ダミータイトル1");
       expect(body).toEqual("変更後のボディ");
     });
-    it("id:2のデータ更新(タイトルとボディ)", async () => {
-      const requestBothData = {
+    it("【id:2のデータ更新】タイトルとボディ", async () => {
+      const data = {
         title: "変更後のタイトル",
         body: "変更後のボディ",
       };
@@ -63,7 +63,7 @@ describe("【APIテスト】Todo一件の更新", () => {
         method: "put",
         endPoint: "/api/todos/2",
         statusCode: StatusCodes.OK,
-      }).send(requestBothData);
+      }).send(data);
 
       const { id, title, body } = response.body;
 
@@ -73,35 +73,35 @@ describe("【APIテスト】Todo一件の更新", () => {
     });
   });
   describe("【異常パターン】", () => {
-    it("タイトルに不適切な値(文字列ではない値)が入力された場合、リクエストはエラーになる", async () => {
-      const badInputCharacter = 123;
+    it("タイトルに不適切な値(文字列ではない値)が入力された場合、リクエストはエラーになる。", async () => {
+      const data = 123;
 
       const response = await requestAPI({
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.BAD_REQUEST,
-      }).send({ title: badInputCharacter });
+      }).send({ title: data });
 
       expect(response.body).toEqual({
         message: "入力内容が不適切(文字列のみ)です。",
       });
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
     });
-    it("ボディに不適切な値(文字列ではない値)が入力された場合、リクエストはエラーになる", async () => {
-      const badInputCharacter = 123;
+    it("ボディに不適切な値(文字列ではない値)が入力された場合、リクエストはエラーになる。", async () => {
+      const data = 123;
 
       const response = await requestAPI({
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.BAD_REQUEST,
-      }).send({ body: badInputCharacter });
+      }).send({ body: data });
 
       expect(response.body).toEqual({
         message: "入力内容が不適切(文字列のみ)です。",
       });
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
     });
-    it("存在しないIDへのリクエストはエラーになる", async () => {
+    it("存在しないIDへのリクエストはエラーになる。", async () => {
       const response = await requestAPI({
         method: "put",
         endPoint: "/api/todos/999",
@@ -113,7 +113,7 @@ describe("【APIテスト】Todo一件の更新", () => {
       });
       expect(response.statusCode).toEqual(StatusCodes.NOT_FOUND);
     });
-    it("プログラムの意図しないエラー(サーバー側の問題等)は、エラーメッセージ(InternalServerError)とstatus(InternalServerError=500)が返る", async () => {
+    it("プログラムの意図しないエラー(サーバー側の問題等)は、エラーメッセージ(InternalServerError)とstatus(InternalServerError=500)が返る。", async () => {
       jest.spyOn(TodoRepository.prototype, "update").mockImplementation(() => {
         throw new Error("Unexpected Error");
       });

--- a/src/__test__/controllers/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/UpdateTodoController.spec.ts
@@ -113,7 +113,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
       });
     });
     describe("【異常パターン】", () => {
-      it("【タイトルに不適切な値(文字列ではない値)が入力された場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
+      it("【タイトルに不適切な値(文字列ではない値)が入力された場合】next関数(パラメーターがInvalidError)を実行する。", async () => {
         const req = createMockRequest({
           params: { id: "1" },
           body: { title: 111, body: "変更後のボディ" },

--- a/src/__test__/controllers/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/controllers/todos/UpdateTodoController.spec.ts
@@ -15,7 +15,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
     controller = new UpdateTodoController(repository);
   });
   describe("【成功パターン】", () => {
-    it("updateメソッドのパラメーターが【id:1、title:変更後のタイトル】で呼び出され、更新後のデータが返る。", async () => {
+    it("updateメソッドのパラメーターが【id:1・title:変更後のタイトル】で呼び出され、更新後のデータが返る。", async () => {
       const req = createMockRequest({
         params: { id: "1" },
         body: { title: "変更後のタイトル" },
@@ -113,7 +113,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
       });
     });
     describe("【異常パターン】", () => {
-      it("タイトルに不適切な値(文字列ではない値)が入力された場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
+      it("【タイトルに不適切な値(文字列ではない値)が入力された場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
         const req = createMockRequest({
           params: { id: "1" },
           body: { title: 111, body: "変更後のボディ" },
@@ -129,7 +129,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
 
         expect(next).toHaveBeenCalledWith(expect.any(InvalidError));
       });
-      it("ボディに不適切な値(文字列ではない値)が入力された場合、next関数(パラメーターがInvalidError)を実行する。", async () => {
+      it("【ボディに不適切な値(文字列ではない値)が入力された場合】next関数(パラメーターがInvalidError)を実行する。", async () => {
         const req = createMockRequest({
           params: { id: "1" },
           body: { title: "変更後のタイトル", body: 222 },
@@ -145,7 +145,7 @@ describe("【ユニットテスト】 Todo一件の更新", () => {
 
         expect(next).toHaveBeenCalledWith(expect.any(InvalidError));
       });
-      it("存在しないIDへのリクエストは、next関数(パラメーターがNotFoundError)を実行する。", async () => {
+      it("【存在しないIDにリクエストした場合】next関数(パラメーターがNotFoundError)を実行する。", async () => {
         const req = createMockRequest({
           params: { id: "999" },
           body: { title: "変更後のタイトル", body: "変更後のボディ" },

--- a/src/__test__/schemas/shared/idParamsSchema.spec.ts
+++ b/src/__test__/schemas/shared/idParamsSchema.spec.ts
@@ -5,7 +5,7 @@ import { idParamsSchema } from "../../../schemas/shared/idParamsSchema";
 describe("【ユニットテスト】idParamsSchemaの挙動テスト", () => {
   describe("【成功パターン】", () => {
     it("【バリデーションに成功した場合】例外が発生しない。", () => {
-      const data = { id: "1" };
+      const data = "1";
       const result = idParamsSchema.parse(data);
 
       expect(result).toEqual(data);
@@ -13,14 +13,14 @@ describe("【ユニットテスト】idParamsSchemaの挙動テスト", () => {
   });
   describe("【異常パターン】", () => {
     it("【IDの入力値が不正(整数の1以上でない値)な場合】例外が発生する。", () => {
-      const data = { id: "0" };
+      const data = "0";
 
       expect(() => idParamsSchema.parse(data)).toThrow(
         new ZodError([
           {
             code: "custom",
             message: "IDは1以上の整数のみ。",
-            path: ["id"],
+            path: [],
           },
         ]),
       );

--- a/src/__test__/schemas/todos/getTodoSchema.spec.ts
+++ b/src/__test__/schemas/todos/getTodoSchema.spec.ts
@@ -2,7 +2,7 @@ import { ZodError } from "zod";
 
 import { getTodoSchema } from "../../../schemas/todos/getTodoSchema";
 
-describe("【ユニットテスト】idParamsSchemaの挙動テスト", () => {
+describe("【ユニットテスト】getTodoSchemaの挙動テスト", () => {
   describe("【成功パターン】", () => {
     it("【バリデーションに成功した場合】例外が発生しない。", () => {
       const data = { params: { id: "1" } };

--- a/src/__test__/schemas/todos/getTodoSchema.spec.ts
+++ b/src/__test__/schemas/todos/getTodoSchema.spec.ts
@@ -1,26 +1,26 @@
 import { ZodError } from "zod";
 
-import { idParamsSchema } from "../../../schemas/shared/idParamsSchema";
+import { getTodoSchema } from "../../../schemas/todos/getTodoSchema";
 
 describe("【ユニットテスト】idParamsSchemaの挙動テスト", () => {
   describe("【成功パターン】", () => {
     it("【バリデーションに成功した場合】例外が発生しない。", () => {
-      const data = { id: "1" };
-      const result = idParamsSchema.parse(data);
+      const data = { params: { id: "1" } };
+      const result = getTodoSchema.parse(data);
 
       expect(result).toEqual(data);
     });
   });
   describe("【異常パターン】", () => {
     it("【IDの入力値が不正(整数の1以上でない値)な場合】例外が発生する。", () => {
-      const data = { id: "0" };
+      const data = { params: { id: "0" } };
 
-      expect(() => idParamsSchema.parse(data)).toThrow(
+      expect(() => getTodoSchema.parse(data)).toThrow(
         new ZodError([
           {
             code: "custom",
             message: "IDは1以上の整数のみ。",
-            path: ["id"],
+            path: ["params", "id"],
           },
         ]),
       );

--- a/src/__test__/schemas/todos/getTodoSchema.spec.ts
+++ b/src/__test__/schemas/todos/getTodoSchema.spec.ts
@@ -5,7 +5,7 @@ import { getTodoSchema } from "../../../schemas/todos/getTodoSchema";
 describe("【ユニットテスト】getTodoSchemaの挙動テスト", () => {
   describe("【成功パターン】", () => {
     it("【バリデーションに成功した場合】例外が発生しない。", () => {
-      const data = { params: "1" };
+      const data = { params: { id: "1" } };
       const result = getTodoSchema.parse(data);
 
       expect(result).toEqual(data);
@@ -13,14 +13,14 @@ describe("【ユニットテスト】getTodoSchemaの挙動テスト", () => {
   });
   describe("【異常パターン】", () => {
     it("【IDの入力値が不正(整数の1以上でない値)な場合】例外が発生する。", () => {
-      const data = { params: "0" };
+      const data = { params: { id: "0" } };
 
       expect(() => getTodoSchema.parse(data)).toThrow(
         new ZodError([
           {
             code: "custom",
             message: "IDは1以上の整数のみ。",
-            path: ["params"],
+            path: ["params", "id"],
           },
         ]),
       );

--- a/src/__test__/schemas/todos/getTodoSchema.spec.ts
+++ b/src/__test__/schemas/todos/getTodoSchema.spec.ts
@@ -5,7 +5,7 @@ import { getTodoSchema } from "../../../schemas/todos/getTodoSchema";
 describe("【ユニットテスト】getTodoSchemaの挙動テスト", () => {
   describe("【成功パターン】", () => {
     it("【バリデーションに成功した場合】例外が発生しない。", () => {
-      const data = { params: { id: "1" } };
+      const data = { params: "1" };
       const result = getTodoSchema.parse(data);
 
       expect(result).toEqual(data);
@@ -13,14 +13,14 @@ describe("【ユニットテスト】getTodoSchemaの挙動テスト", () => {
   });
   describe("【異常パターン】", () => {
     it("【IDの入力値が不正(整数の1以上でない値)な場合】例外が発生する。", () => {
-      const data = { params: { id: "0" } };
+      const data = { params: "0" };
 
       expect(() => getTodoSchema.parse(data)).toThrow(
         new ZodError([
           {
             code: "custom",
             message: "IDは1以上の整数のみ。",
-            path: ["params", "id"],
+            path: ["params"],
           },
         ]),
       );

--- a/src/__test__/schemas/todos/updateTodoSchema.spec.ts
+++ b/src/__test__/schemas/todos/updateTodoSchema.spec.ts
@@ -6,9 +6,7 @@ describe("【ユニットテスト】updateTodoSchemaの挙動テスト", () => 
   describe("【成功パターン】", () => {
     it("【バリデーションに成功した場合】例外が発生しない。", () => {
       const data = {
-        params: {
-          id: "1",
-        },
+        params: "1",
         body: {
           title: "変更後のタイトル",
           body: "変更後のボディ",
@@ -23,7 +21,7 @@ describe("【ユニットテスト】updateTodoSchemaの挙動テスト", () => 
   describe("【異常パターン】", () => {
     it("【IDの入力値が不正(整数の1以上でない値)な場合】例外が発生する。", () => {
       const data = {
-        params: { id: "0" },
+        params: "0",
         body: {
           title: "変更後のタイトル",
           body: "変更後のボディ",
@@ -35,14 +33,14 @@ describe("【ユニットテスト】updateTodoSchemaの挙動テスト", () => 
           {
             code: "custom",
             message: "IDは1以上の整数のみ。",
-            path: ["params", "id"],
+            path: ["params"],
           },
         ]),
       );
     });
     it("【タイトルに不適切な値(文字列ではない値)が入力された場合】例外が発生する。", () => {
       const data = {
-        params: { id: "1" },
+        params: "1",
         body: {
           title: 123,
           body: 456,

--- a/src/__test__/schemas/todos/updateTodoSchema.spec.ts
+++ b/src/__test__/schemas/todos/updateTodoSchema.spec.ts
@@ -1,0 +1,72 @@
+import { ZodError } from "zod";
+
+import { updateTodoSchema } from "../../../schemas/todos/updateTodoSchema";
+
+describe("【ユニットテスト】updateTodoSchemaの挙動テスト", () => {
+  describe("【成功パターン】", () => {
+    it("【バリデーションに成功した場合】例外が発生しない。", () => {
+      const data = {
+        params: {
+          id: "1",
+        },
+        body: {
+          title: "変更後のタイトル",
+          body: "変更後のボディ",
+        },
+      };
+
+      const result = updateTodoSchema.parse(data);
+
+      expect(result).toEqual(data);
+    });
+  });
+  describe("【異常パターン】", () => {
+    it("【IDの入力値が不正(整数の1以上でない値)な場合】例外が発生する。", () => {
+      const data = {
+        params: { id: "0" },
+        body: {
+          title: "変更後のタイトル",
+          body: "変更後のボディ",
+        },
+      };
+
+      expect(() => updateTodoSchema.parse(data)).toThrow(
+        new ZodError([
+          {
+            code: "custom",
+            message: "IDは1以上の整数のみ。",
+            path: ["params", "id"],
+          },
+        ]),
+      );
+    });
+    it("【タイトルに不適切な値(文字列ではない値)が入力された場合】例外が発生する。", () => {
+      const data = {
+        params: { id: "1" },
+        body: {
+          title: 123,
+          body: 456,
+        },
+      };
+
+      expect(() => updateTodoSchema.parse(data)).toThrow(
+        new ZodError([
+          {
+            code: "invalid_type",
+            expected: "string",
+            received: "number",
+            path: ["body", "title"],
+            message: "入力内容が不適切(文字列のみ)です。",
+          },
+          {
+            code: "invalid_type",
+            expected: "string",
+            received: "number",
+            path: ["body", "body"],
+            message: "入力内容が不適切(文字列のみ)です。",
+          },
+        ]),
+      );
+    });
+  });
+});

--- a/src/__test__/schemas/todos/updateTodoSchema.spec.ts
+++ b/src/__test__/schemas/todos/updateTodoSchema.spec.ts
@@ -6,7 +6,7 @@ describe("【ユニットテスト】updateTodoSchemaの挙動テスト", () => 
   describe("【成功パターン】", () => {
     it("【バリデーションに成功した場合】例外が発生しない。", () => {
       const data = {
-        params: "1",
+        params: { id: "1" },
         body: {
           title: "変更後のタイトル",
           body: "変更後のボディ",
@@ -21,7 +21,7 @@ describe("【ユニットテスト】updateTodoSchemaの挙動テスト", () => 
   describe("【異常パターン】", () => {
     it("【IDの入力値が不正(整数の1以上でない値)な場合】例外が発生する。", () => {
       const data = {
-        params: "0",
+        params: { id: "0" },
         body: {
           title: "変更後のタイトル",
           body: "変更後のボディ",
@@ -33,14 +33,14 @@ describe("【ユニットテスト】updateTodoSchemaの挙動テスト", () => 
           {
             code: "custom",
             message: "IDは1以上の整数のみ。",
-            path: ["params"],
+            path: ["params", "id"],
           },
         ]),
       );
     });
     it("【タイトルに不適切な値(文字列ではない値)が入力された場合】例外が発生する。", () => {
       const data = {
-        params: "1",
+        params: { id: "1" },
         body: {
           title: 123,
           body: 456,

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -65,13 +65,6 @@ export class TodoRepository implements ITodoRepository {
   }
 
   async update({ id, title, body }: TodoUpdatedInput) {
-    if (
-      (title && typeof title !== "string") ||
-      (body && typeof body !== "string")
-    ) {
-      throw new InvalidError("入力内容が不適切(文字列のみ)です。");
-    }
-
     const updateItem = await prisma.todo.findUnique({
       where: { id: id },
     });

--- a/src/routers/todos.ts
+++ b/src/routers/todos.ts
@@ -7,8 +7,8 @@ import { GetTodosController } from "../controllers/todos/GetTodosController";
 import { UpdateTodoController } from "../controllers/todos/UpdateTodoController";
 import { validator } from "../middlewares/validateHandler";
 import { TodoRepository } from "../repositories/TodoRepository";
-import { idParamsSchema } from "../schemas/shared/idParamsSchema";
 import { createTodoSchema } from "../schemas/todos/createTodoSchema";
+import { getTodoSchema } from "../schemas/todos/getTodoSchema";
 import { getTodosSchema } from "../schemas/todos/getTodosSchema";
 import { updateTodoSchema } from "../schemas/todos/updateTodoSchema";
 
@@ -32,7 +32,7 @@ router
 
 router
   .route("/:id")
-  .get(validator(idParamsSchema), (req, res, next) => {
+  .get(validator(getTodoSchema), (req, res, next) => {
     todoGetController.find(req, res, next);
   })
   .put(validator(updateTodoSchema), (req, res, next) => {

--- a/src/routers/todos.ts
+++ b/src/routers/todos.ts
@@ -10,6 +10,7 @@ import { TodoRepository } from "../repositories/TodoRepository";
 import { idParamsSchema } from "../schemas/shared/idParamsSchema";
 import { createTodoSchema } from "../schemas/todos/createTodoSchema";
 import { getTodosSchema } from "../schemas/todos/getTodosSchema";
+import { updateTodoSchema } from "../schemas/todos/updateTodoSchema";
 
 const router = express.Router();
 
@@ -34,7 +35,7 @@ router
   .get(validator(idParamsSchema), (req, res, next) => {
     todoGetController.find(req, res, next);
   })
-  .put((req, res, next) => {
+  .put(validator(updateTodoSchema), (req, res, next) => {
     todoUpdateController.update(req, res, next);
   })
   .delete((req, res, next) => {

--- a/src/schemas/shared/idParamsSchema.ts
+++ b/src/schemas/shared/idParamsSchema.ts
@@ -1,12 +1,10 @@
 import { z } from "zod";
 
-export const idParamsSchema = z.object({
-  id: z.string().refine(
-    (id) => {
-      return Number(id) > 0;
-    },
-    {
-      message: "IDは1以上の整数のみ。",
-    },
-  ),
-});
+export const idParamsSchema = z.string().refine(
+  (id) => {
+    return Number(id) > 0;
+  },
+  {
+    message: "IDは1以上の整数のみ。",
+  },
+);

--- a/src/schemas/shared/idParamsSchema.ts
+++ b/src/schemas/shared/idParamsSchema.ts
@@ -1,14 +1,12 @@
 import { z } from "zod";
 
 export const idParamsSchema = z.object({
-  params: z.object({
-    id: z.string().refine(
-      (id) => {
-        return Number(id) > 0;
-      },
-      {
-        message: "IDは1以上の整数のみ。",
-      },
-    ),
-  }),
+  id: z.string().refine(
+    (id) => {
+      return Number(id) > 0;
+    },
+    {
+      message: "IDは1以上の整数のみ。",
+    },
+  ),
 });

--- a/src/schemas/todos/getTodoSchema.ts
+++ b/src/schemas/todos/getTodoSchema.ts
@@ -3,5 +3,5 @@ import { z } from "zod";
 import { idParamsSchema } from "../shared/idParamsSchema";
 
 export const getTodoSchema = z.object({
-  params: idParamsSchema,
+  params: z.object({ id: idParamsSchema }),
 });

--- a/src/schemas/todos/getTodoSchema.ts
+++ b/src/schemas/todos/getTodoSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+import { idParamsSchema } from "../shared/idParamsSchema";
+
+export const getTodoSchema = z.object({
+  params: idParamsSchema,
+});

--- a/src/schemas/todos/updateTodoSchema.ts
+++ b/src/schemas/todos/updateTodoSchema.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { idParamsSchema } from "../shared/idParamsSchema";
 
 export const updateTodoSchema = z.object({
-  params: idParamsSchema,
+  params: z.object({ id: idParamsSchema }),
   body: z.object({
     title: z
       .string({

--- a/src/schemas/todos/updateTodoSchema.ts
+++ b/src/schemas/todos/updateTodoSchema.ts
@@ -1,16 +1,9 @@
 import { z } from "zod";
 
+import { idParamsSchema } from "../shared/idParamsSchema";
+
 export const updateTodoSchema = z.object({
-  params: z.object({
-    id: z.string().refine(
-      (id) => {
-        return Number(id) > 0;
-      },
-      {
-        message: "IDは1以上の整数のみ。",
-      },
-    ),
-  }),
+  params: idParamsSchema,
   body: z.object({
     title: z
       .string({

--- a/src/schemas/todos/updateTodoSchema.ts
+++ b/src/schemas/todos/updateTodoSchema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const updateTodoSchema = z.object({
+  params: z.object({
+    id: z.string().refine(
+      (id) => {
+        return Number(id) > 0;
+      },
+      {
+        message: "IDは1以上の整数のみ。",
+      },
+    ),
+  }),
+  body: z.object({
+    title: z
+      .string({
+        invalid_type_error: "入力内容が不適切(文字列のみ)です。",
+      })
+      .optional(),
+    body: z
+      .string({
+        invalid_type_error: "入力内容が不適切(文字列のみ)です。",
+      })
+      .optional(),
+  }),
+});


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

今回の修正も、
以前に実装したschemaの作成と
ミドルウェアの追加となります。

リポジトリのガード節を削除し、
ルーターにvalidation処理を追加しました。
![スクリーンショット 2024-09-13 210428](https://github.com/user-attachments/assets/caaeee94-e271-4ff3-bff4-d973409b066b)

schemaについては、
前田さんのコメントを参考にしましたが、
以下では処理が出ませんでした。
![スクリーンショット 2024-09-13 152722](https://github.com/user-attachments/assets/6f13a335-2530-4b4f-affd-af2eabb03f65)

idのvalidationが重複してしまいますが、
今回の実装以外に方法が考えられませんでした。
![image](https://github.com/user-attachments/assets/4d0e0766-bf5e-4b9f-8880-e4eaf2a2a913)

後は、
ユニットテストとインテグレーションテストの
リファクタリングを行いました。

よろしくお願いします。



