### PR TITLE
【Todoのリファクタリング】～UserRepository実装後のリレーションの為～

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -18,10 +18,10 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await resetDatabase();
+  await prisma.user.deleteMany();
   await prisma.$disconnect();
 });
 
 async function resetDatabase() {
   await prisma.todo.deleteMany();
-  await prisma.user.deleteMany();
 }

--- a/src/__test__/app/api/todos/CreateTodoController.spec.ts
+++ b/src/__test__/app/api/todos/CreateTodoController.spec.ts
@@ -9,7 +9,7 @@ const prisma = new PrismaClient();
 
 describe("【APIテスト】 Todo1件新規作成", () => {
   describe("【成功パターン】", () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
       for (let i = 1; i <= 2; i++) {
         await prisma.user.create({
           data: {

--- a/src/__test__/app/api/todos/CreateTodoController.spec.ts
+++ b/src/__test__/app/api/todos/CreateTodoController.spec.ts
@@ -1,14 +1,30 @@
 import { StatusCodes } from "http-status-codes";
 
+import { PrismaClient } from "@prisma/client";
+
 import { TodoRepository } from "../../../../repositories/TodoRepository";
 import { requestAPI } from "../../../helper/requestHelper";
 
+const prisma = new PrismaClient();
+
 describe("【APIテスト】 Todo1件新規作成", () => {
   describe("【成功パターン】", () => {
+    beforeEach(async () => {
+      for (let i = 1; i <= 2; i++) {
+        await prisma.user.create({
+          data: {
+            name: `ダミーユーザー${i}`,
+            password: `dammyPassword${i}`,
+            email: `dammyData${i}@mail.com`,
+          },
+        });
+      }
+    });
     it("title.bodyを送ったら成功する", async () => {
       const request = {
         title: "ダミータイトル",
         body: "ダミーボディ",
+        user_id: 1,
       };
 
       const response = await requestAPI({
@@ -25,6 +41,7 @@ describe("【APIテスト】 Todo1件新規作成", () => {
         body: "ダミーボディ",
         createdAt: responseDataResult.createdAt,
         updatedAt: responseDataResult.updatedAt,
+        user_id: responseDataResult.user_id,
       });
 
       expect(typeof Number(responseDataResult.id)).toEqual("number");
@@ -38,7 +55,7 @@ describe("【APIテスト】 Todo1件新規作成", () => {
   });
   describe("【異常パターン】", () => {
     it("【titleプロパティの入力値がない場合】createTodoSchemaに基づくInvalidErrorのテスト。", async () => {
-      const request = { body: "ダミーボディ" };
+      const request = { body: "ダミーボディ", user_id: 1 };
 
       const response = await requestAPI({
         method: "post",
@@ -52,7 +69,7 @@ describe("【APIテスト】 Todo1件新規作成", () => {
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
     });
     it("【titleプロパティ有り・入力値(1文字以上)がない場合】createTodoSchemaに基づくInvalidErrorのテスト。", async () => {
-      const request = { title: "", body: "ダミーボディ" };
+      const request = { title: "", body: "ダミーボディ", user_id: 1 };
 
       const response = await requestAPI({
         method: "post",
@@ -66,7 +83,7 @@ describe("【APIテスト】 Todo1件新規作成", () => {
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
     });
     it("【bodyプロパティの入力値がない場合】createTodoSchemaに基づくInvalidErrorのテスト。", async () => {
-      const request = { title: "ダミータイトル" };
+      const request = { title: "ダミータイトル", user_id: 1 };
 
       const response = await requestAPI({
         method: "post",
@@ -80,7 +97,7 @@ describe("【APIテスト】 Todo1件新規作成", () => {
       expect(response.statusCode).toEqual(StatusCodes.BAD_REQUEST);
     });
     it("【bodyプロパティ有り・入力値(1文字以上)がない場合】createTodoSchemaに基づくInvalidErrorのテスト。", async () => {
-      const request = { title: "ダミータイトル", body: "" };
+      const request = { title: "ダミータイトル", body: "", user_id: 1 };
 
       const response = await requestAPI({
         method: "post",
@@ -104,6 +121,7 @@ describe("【APIテスト】 Todo1件新規作成", () => {
       }).send({
         title: "ダミータイトル",
         body: "ダミーボディ",
+        user_id: 1,
       });
 
       expect(response.body).toEqual({ message: "Internal Server Error" });

--- a/src/__test__/app/api/todos/DeleteTodoController.spec.ts
+++ b/src/__test__/app/api/todos/DeleteTodoController.spec.ts
@@ -9,7 +9,7 @@ const prisma = new PrismaClient();
 
 describe("【APIテスト】 Todo一件の削除", () => {
   describe("【成功パターン】", () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
       for (let i = 1; i <= 3; i++) {
         await prisma.user.create({
           data: {
@@ -19,7 +19,8 @@ describe("【APIテスト】 Todo一件の削除", () => {
           },
         });
       }
-
+    });
+    beforeEach(async () => {
       for (let i = 1; i <= 3; i++) {
         await prisma.todo.create({
           data: {

--- a/src/__test__/app/api/todos/DeleteTodoController.spec.ts
+++ b/src/__test__/app/api/todos/DeleteTodoController.spec.ts
@@ -11,10 +11,23 @@ describe("【APIテスト】 Todo一件の削除", () => {
   describe("【成功パターン】", () => {
     beforeEach(async () => {
       for (let i = 1; i <= 3; i++) {
+        await prisma.user.create({
+          data: {
+            name: `ダミーユーザー${i}`,
+            password: `dammyPassword${i}`,
+            email: `dammyData${i}@mail.com`,
+          },
+        });
+      }
+
+      for (let i = 1; i <= 3; i++) {
         await prisma.todo.create({
           data: {
             title: `ダミータイトル${i}`,
             body: `ダミーボディ${i}`,
+            user: {
+              connect: { id: i },
+            },
           },
         });
       }

--- a/src/__test__/app/api/todos/GetTodoController.spec.ts
+++ b/src/__test__/app/api/todos/GetTodoController.spec.ts
@@ -11,10 +11,21 @@ describe("【APIテスト】 Todo1件の取得", () => {
   describe("【成功パターン】", () => {
     beforeEach(async () => {
       for (let i = 1; i <= 2; i++) {
+        await prisma.user.create({
+          data: {
+            name: `ダミーユーザー${i}`,
+            password: `dammyPassword${i}`,
+            email: `dammyData${i}@mail.com`,
+          },
+        });
+      }
+
+      for (let i = 1; i <= 2; i++) {
         await prisma.todo.create({
           data: {
             title: `ダミータイトル${i}`,
             body: `ダミーボディ${i}`,
+            user_id: i,
           },
         });
       }

--- a/src/__test__/app/api/todos/GetTodoController.spec.ts
+++ b/src/__test__/app/api/todos/GetTodoController.spec.ts
@@ -9,7 +9,7 @@ const prisma = new PrismaClient();
 
 describe("【APIテスト】 Todo1件の取得", () => {
   describe("【成功パターン】", () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
       for (let i = 1; i <= 2; i++) {
         await prisma.user.create({
           data: {
@@ -19,7 +19,8 @@ describe("【APIテスト】 Todo1件の取得", () => {
           },
         });
       }
-
+    });
+    beforeEach(async () => {
       for (let i = 1; i <= 2; i++) {
         await prisma.todo.create({
           data: {

--- a/src/__test__/app/api/todos/GetTodosController.spec.ts
+++ b/src/__test__/app/api/todos/GetTodosController.spec.ts
@@ -10,7 +10,7 @@ const prisma = new PrismaClient();
 
 describe("【APIテスト】 Todo一覧取得", () => {
   describe("【DBにデータあり】", () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
       for (let i = 1; i <= 20; i++) {
         await prisma.user.create({
           data: {
@@ -20,7 +20,8 @@ describe("【APIテスト】 Todo一覧取得", () => {
           },
         });
       }
-
+    });
+    beforeEach(async () => {
       for (let i = 1; i <= 20; i++) {
         await prisma.todo.create({
           data: {

--- a/src/__test__/app/api/todos/GetTodosController.spec.ts
+++ b/src/__test__/app/api/todos/GetTodosController.spec.ts
@@ -12,10 +12,21 @@ describe("【APIテスト】 Todo一覧取得", () => {
   describe("【DBにデータあり】", () => {
     beforeEach(async () => {
       for (let i = 1; i <= 20; i++) {
+        await prisma.user.create({
+          data: {
+            name: `ダミーユーザー${i}`,
+            password: `dammyPassword${i}`,
+            email: `dammyData${i}@mail.com`,
+          },
+        });
+      }
+
+      for (let i = 1; i <= 20; i++) {
         await prisma.todo.create({
           data: {
             title: `ダミータイトル${i}`,
             body: `ダミーボディ${i}`,
+            user_id: i,
           },
         });
       }

--- a/src/__test__/app/api/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/app/api/todos/UpdateTodoController.spec.ts
@@ -11,10 +11,23 @@ describe("【APIテスト】Todo一件の更新", () => {
   describe("【成功パターン】", () => {
     beforeEach(async () => {
       for (let i = 1; i <= 2; i++) {
+        await prisma.user.create({
+          data: {
+            name: `ダミーユーザー${i}`,
+            password: `dammyPassword${i}`,
+            email: `dammyData${i}@mail.com`,
+          },
+        });
+      }
+
+      for (let i = 1; i <= 2; i++) {
         await prisma.todo.create({
           data: {
             title: `ダミータイトル${i}`,
             body: `ダミーボディ${i}`,
+            user: {
+              connect: { id: i },
+            },
           },
         });
       }
@@ -22,6 +35,7 @@ describe("【APIテスト】Todo一件の更新", () => {
     it("【id:1のデータ更新】タイトルのみ", async () => {
       const data = {
         title: "変更後のタイトル",
+        user_id: 1,
       };
 
       const response = await requestAPI({
@@ -39,6 +53,7 @@ describe("【APIテスト】Todo一件の更新", () => {
     it("【id:1のデータ更新】ボディのみ", async () => {
       const data = {
         body: "変更後のボディ",
+        user_id: 1,
       };
 
       const response = await requestAPI({
@@ -57,6 +72,7 @@ describe("【APIテスト】Todo一件の更新", () => {
       const data = {
         title: "変更後のタイトル",
         body: "変更後のボディ",
+        user_id: 2,
       };
 
       const response = await requestAPI({
@@ -80,7 +96,7 @@ describe("【APIテスト】Todo一件の更新", () => {
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.BAD_REQUEST,
-      }).send({ title: data });
+      }).send({ title: data, user_id: 1 });
 
       expect(response.body).toEqual({
         message: "入力内容が不適切(文字列のみ)です。",
@@ -94,7 +110,7 @@ describe("【APIテスト】Todo一件の更新", () => {
         method: "put",
         endPoint: "/api/todos/1",
         statusCode: StatusCodes.BAD_REQUEST,
-      }).send({ body: data });
+      }).send({ body: data, user_id: 1 });
 
       expect(response.body).toEqual({
         message: "入力内容が不適切(文字列のみ)です。",
@@ -106,7 +122,7 @@ describe("【APIテスト】Todo一件の更新", () => {
         method: "put",
         endPoint: "/api/todos/999",
         statusCode: StatusCodes.NOT_FOUND,
-      }).send({ title: "ダミータイトル", body: "ダミーボディ" });
+      }).send({ title: "ダミータイトル", body: "ダミーボディ", user_id: 999 });
 
       expect(response.body).toEqual({
         message: "存在しないIDを指定しました。",

--- a/src/__test__/app/api/todos/UpdateTodoController.spec.ts
+++ b/src/__test__/app/api/todos/UpdateTodoController.spec.ts
@@ -9,7 +9,7 @@ const prisma = new PrismaClient();
 
 describe("【APIテスト】Todo一件の更新", () => {
   describe("【成功パターン】", () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
       for (let i = 1; i <= 2; i++) {
         await prisma.user.create({
           data: {
@@ -19,7 +19,8 @@ describe("【APIテスト】Todo一件の更新", () => {
           },
         });
       }
-
+    });
+    beforeEach(async () => {
       for (let i = 1; i <= 2; i++) {
         await prisma.todo.create({
           data: {

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -8,7 +8,7 @@ const prisma = new PrismaClient();
 
 describe("【TodoRepositoryのテスト】", () => {
   describe("【成功パターン】", () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
       const userRepository = new UserRepository();
 
       for (let i = 1; i <= 21; i++) {

--- a/src/__test__/repositories/UserRepository.spec.ts
+++ b/src/__test__/repositories/UserRepository.spec.ts
@@ -1,8 +1,11 @@
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 
+import { PrismaClient } from "@prisma/client";
+
 import { UserRepository } from "../../repositories/UserRepository";
 
+const prisma = new PrismaClient();
 describe("【UserRepositoryのテスト】", () => {
   describe("【成功パターン】", () => {
     it("【registerメソッド実行時】DBにUserを保持する。", async () => {
@@ -44,6 +47,7 @@ describe("【UserRepositoryのテスト】", () => {
   });
   describe("【異常パターン】", () => {
     it("【registerメソッドを実行時】重複したemailはエラーとなる。", async () => {
+      await prisma.user.deleteMany();
       const repository = new UserRepository();
 
       await repository.register({

--- a/src/controllers/todos/CreateTodoController.ts
+++ b/src/controllers/todos/CreateTodoController.ts
@@ -17,8 +17,8 @@ export class CreateTodoController {
     next: NextFunction,
   ) {
     try {
-      const { title, body } = req.body;
-      const createdTodo = await this.repository.save({ title, body });
+      const { title, body, user_id } = req.body;
+      const createdTodo = await this.repository.save({ title, body, user_id });
 
       res.status(StatusCodes.OK).json(createdTodo);
     } catch (error) {

--- a/src/controllers/todos/UpdateTodoController.ts
+++ b/src/controllers/todos/UpdateTodoController.ts
@@ -14,12 +14,14 @@ export class UpdateTodoController {
     const id = req.params.id;
     const parsedId = parseInt(id, 10);
     const { title, body } = req.body;
+    const user_id = req.body.user_id;
 
     try {
       const responseData = await this.repository.update({
         id: parsedId,
         title: title,
         body: body,
+        user_id: user_id,
       });
 
       res.status(StatusCodes.OK).json(responseData);

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -27,6 +27,9 @@ export class TodoRepository implements ITodoRepository {
       data: {
         title: inputData.title,
         body: inputData.body,
+        user: {
+          connect: { id: inputData.user_id },
+        },
       },
     });
 

--- a/src/types/TodoRequest.type.ts
+++ b/src/types/TodoRequest.type.ts
@@ -1,6 +1,7 @@
 export interface TodoInput {
   title: string;
   body: string;
+  user_id: number;
 }
 
 export interface TodoUpdatedInput extends TodoInput {


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

ユーザー新規登録を行う
コントローラーの
実装に入りましたが、
先にTodoのリファクタリングを
行いました。

上記理由については、
Todoとのリレーションの関係で
結合テストとポストマンを使用しての
動作確認ができませんでした。

リファクタリングの内容は、
結合テストのみ行いました。
(ユニットテストは、結合テストが終わり次第行います。)

テスト毎に、
beforeAllでユーザーの新規登録を
行っています。

後は、補足になりますが、
createTodoコントローラーの
異常テストは修正をせずとも
テストがパスし、修正不要と
考えました。

前回の前田さんの指摘に照らし考えたところ、
![スクリーンショット 2024-09-22 164409](https://github.com/user-attachments/assets/931b57c4-1251-4d99-8e8f-e1773d96c102)
データ形式として含めた方がいいと考え、
テストデータに含めました。
![スクリーンショット 2024-09-22 165025](https://github.com/user-attachments/assets/b98c3ebd-f348-488d-baf0-2700e1e90e0d)
![スクリーンショット 2024-09-22 165039](https://github.com/user-attachments/assets/abe1667f-22fa-4c2b-9af5-be39dfce0c3f)

