### PR TITLE
【Todoのリファクタリング】～UserRepository実装後のリレーションの為～

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -18,10 +18,10 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await resetDatabase();
+  await prisma.user.deleteMany();
   await prisma.$disconnect();
 });
 
 async function resetDatabase() {
   await prisma.todo.deleteMany();
-  await prisma.user.deleteMany();
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,8 +13,8 @@ model Todo {
   body String
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
-  user_id   Int
-  user User    @relation(fields: [user_id], references: [id])
+  userId    Int      @map("user_id") 
+  user User    @relation(fields: [userId], references: [id])
 }
 
 model User {

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -172,10 +172,6 @@ describe("【TodoRepositoryのテスト】", () => {
       expect(async () => {
         await repository.find({ todoId: 999 });
       }).rejects.toThrow("存在しないIDを指定しました。");
-
-      expect(async () => {
-        await repository.find({ todoId: 1 });
-      }).rejects.toThrow("存在しないIDを指定しました。");
     });
     it("【updateメソッド実行時】ユーザーIDがない or 存在しないIDを指定した場合、エラーオブジェクトが返る。", () => {
       const repository = new TodoRepository();

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -7,18 +7,18 @@ import { UserRepository } from "../../repositories/UserRepository";
 const prisma = new PrismaClient();
 
 describe("【TodoRepositoryのテスト】", () => {
-  describe("【成功パターン】", () => {
-    beforeAll(async () => {
-      const repository = new UserRepository();
+  beforeAll(async () => {
+    const repository = new UserRepository();
 
-      for (let i = 1; i <= 21; i++) {
-        await repository.register({
-          name: `ダミーユーザー${i}`,
-          password: `dammyPassword${i}`,
-          email: `dammyData${i}@mail.com`,
-        });
-      }
-    });
+    for (let i = 1; i <= 21; i++) {
+      await repository.register({
+        name: `ダミーユーザー${i}`,
+        password: `dammyPassword${i}`,
+        email: `dammyData${i}@mail.com`,
+      });
+    }
+  });
+  describe("【成功パターン】", () => {
     describe("【saveメソッドのテスト】", () => {
       it("【saveメソッドを実行時】DBに値を保持し、その値に重複しないIDが付与される。", async () => {
         const repository = new TodoRepository();
@@ -50,7 +50,7 @@ describe("【TodoRepositoryのテスト】", () => {
         expect(secondTodo.user_id).toEqual(2);
       });
     });
-    describe("【list・update・deleteメソッドのテスト】", () => {
+    describe("【list・find・update・deleteメソッドのテスト】", () => {
       beforeEach(async () => {
         for (let i = 1; i <= 21; i++) {
           await prisma.todo.create({
@@ -58,7 +58,7 @@ describe("【TodoRepositoryのテスト】", () => {
               title: "ダミータイトル" + i,
               body: "ダミーボディ" + i,
               user: {
-                connect: { id: i },
+                connect: { id: 1 },
               },
             },
           });
@@ -66,7 +66,7 @@ describe("【TodoRepositoryのテスト】", () => {
       });
       it("【listメソッドを実行時】パラメーターの指定がない場合は、先頭から10件のデータを取得する。", async () => {
         const repository = new TodoRepository();
-        const todoList = await repository.list();
+        const todoList = await repository.list({ userId: 1 });
 
         expect(todoList.length).toEqual(10);
         expect(todoList[2].id).toEqual(3);
@@ -75,7 +75,7 @@ describe("【TodoRepositoryのテスト】", () => {
       });
       it("【listメソッドを実行時】パラメーターの指定(page=2)をした場合、11件目のデータから20件のデータを取得する。", async () => {
         const repository = new TodoRepository();
-        const todoList = await repository.list({ page: 2 });
+        const todoList = await repository.list({ userId: 1 }, { page: 2 });
 
         expect(todoList.length).toEqual(10);
         expect(todoList[0].id).toEqual(11);
@@ -84,7 +84,7 @@ describe("【TodoRepositoryのテスト】", () => {
       });
       it("【listメソッドを実行時】パラメーターの指定(count=5)をした場合、先頭から5件のデータを取得する。", async () => {
         const repository = new TodoRepository();
-        const todoList = await repository.list({ count: 5 });
+        const todoList = await repository.list({ userId: 1 }, { count: 5 });
 
         expect(todoList.length).toEqual(5);
         expect(todoList[4].id).toEqual(5);
@@ -93,7 +93,10 @@ describe("【TodoRepositoryのテスト】", () => {
       });
       it("【listメソッドを実行時】パラメーターの指定(page=2,count=3)をした場合、4件目のデータから3件のデータを取得する。", async () => {
         const repository = new TodoRepository();
-        const todoList = await repository.list({ page: 2, count: 3 });
+        const todoList = await repository.list(
+          { userId: 1 },
+          { page: 2, count: 3 },
+        );
 
         expect(todoList.length).toEqual(3);
         expect(todoList[0].id).toEqual(4);
@@ -103,8 +106,8 @@ describe("【TodoRepositoryのテスト】", () => {
       it("【findメソッドを実行時】DBに保持されているデータから、一件のTodoを取得する事ができる。", async () => {
         const repository = new TodoRepository();
 
-        const initialTodo = await repository.find(1);
-        const secondTodo = await repository.find(2);
+        const initialTodo = await repository.find({ userId: 1, todoId: 1 });
+        const secondTodo = await repository.find({ userId: 1, todoId: 2 });
 
         expect(initialTodo?.id).toEqual(1);
         expect(initialTodo?.title).toEqual("ダミータイトル1");
@@ -152,9 +155,9 @@ describe("【TodoRepositoryのテスト】", () => {
       it("【deleteメソッドを実行時】DB内の指定したTodoを削除する事ができる。", async () => {
         const repository = new TodoRepository();
 
-        const oldTodos = await repository.list();
-        const deletedTodo = await repository.delete(1);
-        const newTodos = await repository.list();
+        const oldTodos = await repository.list({ userId: 1 });
+        const deletedTodo = await repository.delete({ userId: 1, todoId: 1 });
+        const newTodos = await repository.list({ userId: 1 });
 
         const oldTodoIds = oldTodos.map((todo) => todo.id);
         const newTodoIds = newTodos.map((todo) => todo.id);
@@ -166,30 +169,65 @@ describe("【TodoRepositoryのテスト】", () => {
     });
   });
   describe("【異常パターン】", () => {
-    it("【findメソッド実行時】指定したIDのデータがない場合、エラーオブジェクトが返る。", () => {
+    it("【saveメソッド実行時】認証に失敗(ユーザーIDがない)した場合、エラーオブジェクトが返る。", () => {
       const repository = new TodoRepository();
 
       expect(async () => {
-        await repository.find(999);
+        await repository.save({
+          title: "ダミータイトル1",
+          body: "ダミーボディ1",
+          user: { id: 999 },
+        });
+      }).rejects.toThrow("Todoの作成は、認証ユーザーのみ可能です。");
+    });
+    it("【listメソッド実行時】認証に失敗(ユーザーIDがない)した場合、エラーオブジェクトが返る。", () => {
+      const repository = new TodoRepository();
+
+      expect(async () => {
+        await repository.list({ userId: 999 });
+      }).rejects.toThrow("Todoの閲覧は、認証ユーザーのみ可能です。");
+    });
+    it("【findメソッド実行時】認証に失敗(ユーザーIDがない) or 存在しないIDを指定した場合、エラーオブジェクトが返る。", () => {
+      const repository = new TodoRepository();
+
+      expect(async () => {
+        await repository.find({ userId: 999, todoId: 1 });
+      }).rejects.toThrow("Todoの閲覧は、認証ユーザーのみ可能です。");
+
+      expect(async () => {
+        await repository.find({ userId: 1, todoId: 999 });
       }).rejects.toThrow("存在しないIDを指定しました。");
     });
-    it("【updateメソッド実行時】指定したIDのデータがない場合、エラーオブジェクトが返る。", () => {
+    it("【updateメソッド実行時】認証に失敗(ユーザーIDがない) or 存在しないIDを指定した場合、エラーオブジェクトが返る。", () => {
       const repository = new TodoRepository();
+
+      expect(async () => {
+        await repository.update({
+          id: 1,
+          title: "変更後のタイトル",
+          body: "変更後のボディ",
+          user: { id: 999 },
+        });
+      }).rejects.toThrow("Todoの更新は、認証ユーザーのみ可能です。");
 
       expect(async () => {
         await repository.update({
           id: 999,
           title: "変更後のタイトル",
           body: "変更後のボディ",
-          user: { id: 999 },
+          user: { id: 1 },
         });
       }).rejects.toThrow("存在しないIDを指定しました。");
     });
-    it("【deleteメソッド実行時】指定したIDのデータがない場合、エラーオブジェクトが返る。", () => {
+    it("【deleteメソッド実行時】認証に失敗(ユーザーIDがない) or 存在しないIDを指定した場合、エラーオブジェクトが返る。", () => {
       const repository = new TodoRepository();
 
       expect(async () => {
-        await repository.delete(999);
+        await repository.delete({ userId: 999, todoId: 1 });
+      }).rejects.toThrow("Todoの削除は、認証ユーザーのみ可能です。");
+
+      expect(async () => {
+        await repository.delete({ userId: 1, todoId: 999 });
       }).rejects.toThrow("存在しないIDを指定しました。");
     });
   });

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 import type { Todo } from "@prisma/client";
 
-import { DatabaseError } from "../../errors/DatabaseError";
+import { InternalServerError } from "../../errors/InternalServerError";
 import { TodoRepository } from "../../repositories/TodoRepository";
 import { UserRepository } from "../../repositories/UserRepository";
 
@@ -195,11 +195,11 @@ describe("【TodoRepositoryのテスト】", () => {
         });
       }).rejects.toThrow("Todoの更新に失敗しました。");
     });
-    it("【updateメソッド実行時】プログラムの意図しないエラー(DB側の問題等)は、DatabaseError(InternalServerError)が返る。", async () => {
+    it("【updateメソッド実行時】プログラムの意図しないエラー(DB側の問題等)は、InternalServerErrorが返る。", async () => {
       const repository = new TodoRepository();
 
       jest.spyOn(repository, "update").mockImplementationOnce(async () => {
-        throw new DatabaseError("データベースにエラーが発生しました。");
+        throw new InternalServerError("データベースにエラーが発生しました。");
       });
 
       await expect(
@@ -222,11 +222,11 @@ describe("【TodoRepositoryのテスト】", () => {
         await repository.delete({ userId: 999, todoId: 1 });
       }).rejects.toThrow("Todoの削除に失敗しました。");
     });
-    it("【deleteメソッド実行時】プログラムの意図しないエラー(DB側の問題等)は、DatabaseError(InternalServerError)が返る。", async () => {
+    it("【deleteメソッド実行時】プログラムの意図しないエラー(DB側の問題等)は、InternalServerErrorが返る。", async () => {
       const repository = new TodoRepository();
 
       jest.spyOn(repository, "delete").mockImplementationOnce(async () => {
-        throw new DatabaseError("データベースにエラーが発生しました。");
+        throw new InternalServerError("データベースにエラーが発生しました。");
       });
 
       await expect(repository.delete({ userId: 1, todoId: 1 })).rejects.toThrow(

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -9,10 +9,10 @@ const prisma = new PrismaClient();
 describe("【TodoRepositoryのテスト】", () => {
   describe("【成功パターン】", () => {
     beforeAll(async () => {
-      const userRepository = new UserRepository();
+      const repository = new UserRepository();
 
       for (let i = 1; i <= 21; i++) {
-        await userRepository.register({
+        await repository.register({
           name: `ダミーユーザー${i}`,
           password: `dammyPassword${i}`,
           email: `dammyData${i}@mail.com`,
@@ -21,15 +21,15 @@ describe("【TodoRepositoryのテスト】", () => {
     });
     describe("【saveメソッドのテスト】", () => {
       it("【saveメソッドを実行時】DBに値を保持し、その値に重複しないIDが付与される。", async () => {
-        const todoRepository = new TodoRepository();
+        const repository = new TodoRepository();
 
-        const initialTodo: Todo = await todoRepository.save({
+        const initialTodo: Todo = await repository.save({
           title: "ダミータイトル1",
           body: "ダミーボディ1",
           user: { id: 1 },
         });
 
-        const secondTodo: Todo = await todoRepository.save({
+        const secondTodo: Todo = await repository.save({
           title: "ダミータイトル2",
           body: "ダミーボディ2",
           user: { id: 2 },

--- a/src/__test__/repositories/TodoRepository.spec.ts
+++ b/src/__test__/repositories/TodoRepository.spec.ts
@@ -2,30 +2,37 @@ import { PrismaClient } from "@prisma/client";
 import type { Todo } from "@prisma/client";
 
 import { TodoRepository } from "../../repositories/TodoRepository";
+import { UserRepository } from "../../repositories/UserRepository";
 
 const prisma = new PrismaClient();
 
 describe("【TodoRepositoryのテスト】", () => {
   describe("【成功パターン】", () => {
-    describe("【インスタンスのテスト】", () => {
-      it("TodoRepositoryのインスタンスが生成される。", () => {
-        const repository = new TodoRepository();
+    beforeAll(async () => {
+      const userRepository = new UserRepository();
 
-        expect(repository).toBeInstanceOf(TodoRepository);
-      });
+      for (let i = 1; i <= 21; i++) {
+        await userRepository.register({
+          name: `ダミーユーザー${i}`,
+          password: `dammyPassword${i}`,
+          email: `dammyData${i}@mail.com`,
+        });
+      }
     });
     describe("【saveメソッドのテスト】", () => {
       it("【saveメソッドを実行時】DBに値を保持し、その値に重複しないIDが付与される。", async () => {
-        const repository = new TodoRepository();
+        const todoRepository = new TodoRepository();
 
-        const initialTodo: Todo = await repository.save({
+        const initialTodo: Todo = await todoRepository.save({
           title: "ダミータイトル1",
           body: "ダミーボディ1",
+          user: { id: 1 },
         });
 
-        const secondTodo: Todo = await repository.save({
+        const secondTodo: Todo = await todoRepository.save({
           title: "ダミータイトル2",
           body: "ダミーボディ2",
+          user: { id: 2 },
         });
 
         expect(initialTodo.id).toEqual(1);
@@ -33,12 +40,14 @@ describe("【TodoRepositoryのテスト】", () => {
         expect(initialTodo.body).toEqual("ダミーボディ1");
         expect(initialTodo.createdAt).toBeInstanceOf(Date);
         expect(initialTodo.updatedAt).toBeInstanceOf(Date);
+        expect(initialTodo.user_id).toEqual(1);
 
         expect(secondTodo.id).toEqual(2);
         expect(secondTodo.title).toEqual("ダミータイトル2");
         expect(secondTodo.body).toEqual("ダミーボディ2");
         expect(secondTodo.createdAt).toBeInstanceOf(Date);
         expect(secondTodo.updatedAt).toBeInstanceOf(Date);
+        expect(secondTodo.user_id).toEqual(2);
       });
     });
     describe("【list・update・deleteメソッドのテスト】", () => {
@@ -48,6 +57,9 @@ describe("【TodoRepositoryのテスト】", () => {
             data: {
               title: "ダミータイトル" + i,
               body: "ダミーボディ" + i,
+              user: {
+                connect: { id: i },
+              },
             },
           });
         }
@@ -113,6 +125,7 @@ describe("【TodoRepositoryのテスト】", () => {
           id: 1,
           title: "変更後のタイトル",
           body: "変更後のボディ",
+          user: { id: 1 },
         });
 
         expect(updatedTodo).toEqual({
@@ -121,6 +134,7 @@ describe("【TodoRepositoryのテスト】", () => {
           body: "変更後のボディ",
           createdAt: updatedTodo.createdAt,
           updatedAt: updatedTodo.updatedAt,
+          user_id: 1,
         });
       });
       it("【updateメソッドを実行時】updatedAtの方がcreatedAtよりも新しい時間になっている。", async () => {
@@ -130,6 +144,7 @@ describe("【TodoRepositoryのテスト】", () => {
           id: 1,
           title: "変更後のタイトル",
           body: "変更後のボディ",
+          user: { id: 1 },
         });
 
         expect(updatedTodo.createdAt < updatedTodo.updatedAt).toBeTruthy();
@@ -166,6 +181,7 @@ describe("【TodoRepositoryのテスト】", () => {
           id: 999,
           title: "変更後のタイトル",
           body: "変更後のボディ",
+          user: { id: 999 },
         });
       }).rejects.toThrow("存在しないIDを指定しました。");
     });

--- a/src/errors/DatabaseError.ts
+++ b/src/errors/DatabaseError.ts
@@ -1,0 +1,10 @@
+import { StatusCodes } from "http-status-codes";
+
+export class DatabaseError extends Error {
+  statusCode: StatusCodes.INTERNAL_SERVER_ERROR;
+
+  constructor(message: string) {
+    super(message);
+    this.statusCode = StatusCodes.INTERNAL_SERVER_ERROR;
+  }
+}

--- a/src/errors/InternalServerError.ts
+++ b/src/errors/InternalServerError.ts
@@ -1,6 +1,6 @@
 import { StatusCodes } from "http-status-codes";
 
-export class DatabaseError extends Error {
+export class InternalServerError extends Error {
   statusCode: StatusCodes.INTERNAL_SERVER_ERROR;
 
   constructor(message: string) {

--- a/src/repositories/ITodoRepository.ts
+++ b/src/repositories/ITodoRepository.ts
@@ -1,12 +1,13 @@
 import type { Todo } from "@prisma/client";
 
-import type { TodoInput } from "../types/TodoRequest.type";
+import type { TodoInput, TodoListParams } from "../types/TodoRequest.type";
 import type { TodoUpdatedInput } from "../types/TodoRequest.type";
+import type { TodoFindParams } from "../types/TodoRequest.type";
 
 export interface ITodoRepository {
   save(inputData: TodoInput): Promise<Todo>;
-  list(todoListRange?: { page?: number; count?: number }): Promise<Todo[]>;
-  find(id: number): Promise<Todo>;
-  update({ id, title, body }: TodoUpdatedInput): Promise<Todo>;
-  delete(id: number): Promise<Todo>;
+  list(inputData: TodoListParams): Promise<Todo[]>;
+  find(inputData: TodoFindParams): Promise<Todo>;
+  update(inputData: TodoUpdatedInput): Promise<Todo>;
+  delete(inputData: TodoFindParams): Promise<Todo>;
 }

--- a/src/repositories/ITodoRepository.ts
+++ b/src/repositories/ITodoRepository.ts
@@ -1,13 +1,17 @@
 import type { Todo } from "@prisma/client";
 
-import type { TodoInput, TodoListParams } from "../types/TodoRequest.type";
-import type { TodoUpdatedInput } from "../types/TodoRequest.type";
+import type {
+  TodoDeletionParams,
+  TodoInput,
+  TodoListParams,
+} from "../types/TodoRequest.type";
+import type { TodoModificationParams } from "../types/TodoRequest.type";
 import type { TodoFindParams } from "../types/TodoRequest.type";
 
 export interface ITodoRepository {
   save(inputData: TodoInput): Promise<Todo>;
   list(inputData: TodoListParams): Promise<Todo[]>;
   find(inputData: TodoFindParams): Promise<Todo>;
-  update(inputData: TodoUpdatedInput): Promise<Todo>;
-  delete(inputData: TodoFindParams): Promise<Todo>;
+  update(inputData: TodoModificationParams): Promise<Todo>;
+  delete(inputData: TodoDeletionParams): Promise<Todo>;
 }

--- a/src/repositories/ITodoRepository.ts
+++ b/src/repositories/ITodoRepository.ts
@@ -2,11 +2,11 @@ import type { Todo } from "@prisma/client";
 
 import type {
   TodoDeletionParams,
+  TodoFindParams,
   TodoInput,
   TodoListParams,
+  TodoModificationParams,
 } from "../types/TodoRequest.type";
-import type { TodoModificationParams } from "../types/TodoRequest.type";
-import type { TodoFindParams } from "../types/TodoRequest.type";
 
 export interface ITodoRepository {
   save(inputData: TodoInput): Promise<Todo>;

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -112,20 +112,3 @@ export class TodoRepository implements ITodoRepository {
     }
   }
 }
-// const updateItem = await prisma.todo.findUnique({
-//   where: { id: inputData.id, userId: inputData.userId },
-// });
-
-// if (!updateItem) {
-//   throw new NotFoundError("Todoの更新に失敗しました。");
-// }
-
-// const updatedItem = await prisma.todo.update({
-//   where: { id: updateItem.id },
-//   data: {
-//     title: inputData.title,
-//     body: inputData.body,
-//   },
-// });
-
-// return updatedItem;

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -27,6 +27,9 @@ export class TodoRepository implements ITodoRepository {
       data: {
         title: inputData.title,
         body: inputData.body,
+        user: {
+          connect: { id: inputData.user.id },
+        },
       },
     });
 

--- a/src/repositories/TodoRepository.ts
+++ b/src/repositories/TodoRepository.ts
@@ -3,7 +3,7 @@ import type { Todo } from "@prisma/client";
 
 import type { ITodoRepository } from "./ITodoRepository";
 
-import { DatabaseError } from "../errors/DatabaseError";
+import { InternalServerError } from "../errors/InternalServerError";
 import { NotFoundError } from "../errors/NotFoundError";
 import type {
   TodoDeletionParams,
@@ -88,7 +88,7 @@ export class TodoRepository implements ITodoRepository {
       ) {
         throw new NotFoundError("Todoの更新に失敗しました。");
       } else {
-        throw new DatabaseError("データベースにエラーが発生しました。");
+        throw new InternalServerError("データベースにエラーが発生しました。");
       }
     }
   }
@@ -107,7 +107,7 @@ export class TodoRepository implements ITodoRepository {
       ) {
         throw new NotFoundError("Todoの削除に失敗しました。");
       } else {
-        throw new DatabaseError("データベースにエラーが発生しました。");
+        throw new InternalServerError("データベースにエラーが発生しました。");
       }
     }
   }

--- a/src/types/TodoRequest.type.ts
+++ b/src/types/TodoRequest.type.ts
@@ -4,11 +4,19 @@ export interface TodoInput {
   user: { id: number };
 }
 
+export interface TodoFindParams {
+  userId: number;
+  todoId: number;
+}
+
 export interface TodoUpdatedInput extends TodoInput {
   id: number;
 }
 
 export interface TodoListParams {
-  page: number;
-  count: number;
+  userId: number;
+  todoListRange?: {
+    page?: number;
+    count?: number;
+  };
 }

--- a/src/types/TodoRequest.type.ts
+++ b/src/types/TodoRequest.type.ts
@@ -1,22 +1,23 @@
 export interface TodoInput {
   title: string;
   body: string;
-  user: { id: number };
+  userId: number;
 }
 
 export interface TodoFindParams {
+  todoId: number;
+}
+
+export interface TodoDeletionParams {
   userId: number;
   todoId: number;
 }
 
-export interface TodoUpdatedInput extends TodoInput {
+export interface TodoModificationParams extends TodoInput {
   id: number;
 }
 
 export interface TodoListParams {
-  userId: number;
-  todoListRange?: {
-    page?: number;
-    count?: number;
-  };
+  page?: number;
+  count?: number;
 }

--- a/src/types/TodoRequest.type.ts
+++ b/src/types/TodoRequest.type.ts
@@ -1,6 +1,7 @@
 export interface TodoInput {
   title: string;
   body: string;
+  user: { id: number };
 }
 
 export interface TodoUpdatedInput extends TodoInput {


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

ユーザーIDの使いまわしについては、
コントローラーの操作と認識しています。

今回のレポジトリの修正は、
リポジトリファイル、テスト共に
コントローラーから認証済みの
ユーザーIDがリクエストされると
想定し、値をそのまま
扱うよう実装しました


各メソッドに、
先ずはユーザーIDの存在の有無を確認する
ガード節を実装し、ユーザーが確認出来たら、
DB操作を行う形としています。
![スクリーンショット 2024-10-05 175133](https://github.com/user-attachments/assets/9aae2354-c0f8-49ac-be47-1087f3fc2d83)

find、deleteは、
ユーザー検索後に
Todoのid検索とTodoの存在の有無
の為、以前実装したガード節をおいています。
![スクリーンショット 2024-10-05 175717](https://github.com/user-attachments/assets/79a38a5a-4bb7-42d1-8448-a0136fc486e3)

テストについては、
ユーザー認証の為のプロパティが
増えた事と、ガード節を増やした為に
テスト行数が多くなりました。

 beforeAllでユーザー登録を一度行い、
以降は、以前実装した内容に、ユーザープロパティを
追加していきました。
![スクリーンショット 2024-10-05 175717](https://github.com/user-attachments/assets/aaa7b75a-cef0-4ff5-8678-f90227ac05e9)

後は、
レポジトリに関連する型を
整理の為、修正を行いました。

![スクリーンショット 2024-10-05 180659](https://github.com/user-attachments/assets/24eb645e-80c4-4a5d-992e-ee38631bafa4)
![スクリーンショット 2024-10-05 180719](https://github.com/user-attachments/assets/053ddd4d-327f-49fa-addd-ad8e42be18cf)





