### PR TITLE
【新規ユーザーの登録機能】～ルーティングの設定とAPIテストの実装～

### DIFF
--- a/src/__test__/app/api/users/RegisterUserController.spec.ts
+++ b/src/__test__/app/api/users/RegisterUserController.spec.ts
@@ -1,0 +1,194 @@
+import { StatusCodes } from "http-status-codes";
+
+import { UserRepository } from "../../../../repositories/users/UserRepository";
+import { requestAPI } from "../../../helper/requestHelper";
+
+describe("【APIテスト】 ユーザーの新規登録", () => {
+  describe("【成功パターン】", () => {
+    it("【name・password・email】を送ったら成功する", async () => {
+      const request = {
+        name: "ダミーユーザー",
+        password: "dummyPassword",
+        email: "dummyData@mail.com",
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.OK,
+      }).send(request);
+
+      const responseUser = response.body;
+      const cookie = response.header["set-cookie"];
+
+      expect(responseUser).toEqual({
+        id: 1,
+        name: "ダミーユーザー",
+        email: "dummyData@mail.com",
+      });
+      expect(cookie[0]).toContain("token=");
+    });
+  });
+  describe("【異常パターン】", () => {
+    it("【registerUserSchemaに基づくInvalidErrorのテスト】nameプロパティの入力値がない場合。", async () => {
+      const request = {
+        password: "dummyPassword",
+        email: "dummyData@mail.com",
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.BAD_REQUEST,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        message: "ユーザー名の入力は必須です。",
+      });
+    });
+    it("【registerUserSchemaに基づくInvalidErrorのテスト】nameプロパティ有り・入力値(1文字以上)がない場合。", async () => {
+      const request = {
+        name: "",
+        password: "dummyPassword",
+        email: "dummyData@mail.com",
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.BAD_REQUEST,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        message: "ユーザー名は1文字以上である必要があります。",
+      });
+    });
+    it("【registerUserSchemaに基づくInvalidErrorのテスト】passwordプロパティの入力値がない場合。", async () => {
+      const request = {
+        name: "ダミーユーザー",
+        email: "dummyData@mail.com",
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.BAD_REQUEST,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        message: "パスワードの入力は必須です。",
+      });
+    });
+    it("【registerUserSchemaに基づくInvalidErrorのテスト】passwordプロパティ有り・入力値が不正(7文字以下)な場合。", async () => {
+      const request = {
+        name: "ダミーユーザー",
+        password: "Invalid",
+        email: "dummyData@mail.com",
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.BAD_REQUEST,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        message: "パスワードは8文字以上である必要があります。",
+      });
+    });
+    it("【registerUserSchemaに基づくInvalidErrorのテスト】passwordプロパティ有り・入力値が不正(16文字より多い場合)な場合。", async () => {
+      const request = {
+        name: "ダミーユーザー",
+        password: "ExcessivePassword",
+        email: "dummyData@mail.com",
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.BAD_REQUEST,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        message: "パスワードは16文字以下である必要があります。",
+      });
+    });
+    it("【registerUserSchemaに基づくInvalidErrorのテスト】emailプロパティの入力値がない場合。", async () => {
+      const request = {
+        name: "ダミーユーザー",
+        password: "dummyPassword",
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.BAD_REQUEST,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        message: "emailの入力は必須です。",
+      });
+    });
+    it("【registerUserSchemaに基づくInvalidErrorのテスト】emailプロパティ有り・入力値が不正(形式が正しくない)な場合。", async () => {
+      const request = {
+        name: "ダミーユーザー",
+        password: "dummyPassword",
+        email: "incorrectFormat.com",
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.BAD_REQUEST,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        message: "emailの形式が正しくありません。",
+      });
+    });
+    it("【ConflictErrorのテスト】email値が重複している場合。", async () => {
+      const request = {
+        name: "ダミーユーザー",
+        password: "dummyPassword",
+        email: "dummyData@mail.com",
+      };
+
+      await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.OK,
+      }).send(request);
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.CONFLICT,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        message: "emailの内容が重複しています。",
+      });
+    });
+    it("プログラムの意図しないエラー(サーバー側の問題等)は、エラーメッセージとstatus(InternalServerError=500)が返る。", async () => {
+      jest
+        .spyOn(UserRepository.prototype, "register")
+        .mockImplementation(() => {
+          throw new Error("Unexpected Error");
+        });
+
+      const request = {
+        name: "ダミーユーザー",
+        password: "dummyPassword",
+        email: "dummyData@mail.com",
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/todos/register",
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+      }).send(request);
+
+      expect(response.body).toEqual({ message: "Internal Server Error" });
+    });
+  });
+});

--- a/src/__test__/app/api/users/RegisterUserController.spec.ts
+++ b/src/__test__/app/api/users/RegisterUserController.spec.ts
@@ -14,7 +14,7 @@ describe("【APIテスト】 ユーザーの新規登録", () => {
 
       const response = await requestAPI({
         method: "post",
-        endPoint: "/api/todos/register",
+        endPoint: "/api/users/register",
         statusCode: StatusCodes.OK,
       }).send(request);
 
@@ -30,165 +30,171 @@ describe("【APIテスト】 ユーザーの新規登録", () => {
     });
   });
   describe("【異常パターン】", () => {
-    it("【registerUserSchemaに基づくInvalidErrorのテスト】nameプロパティの入力値がない場合。", async () => {
-      const request = {
-        password: "dummyPassword",
-        email: "dummyData@mail.com",
-      };
+    describe("【registerUserSchemaに基づくInvalidErrorのテスト】", () => {
+      it("nameプロパティの入力値がない場合。", async () => {
+        const request = {
+          password: "dummyPassword",
+          email: "dummyData@mail.com",
+        };
 
-      const response = await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.BAD_REQUEST,
-      }).send(request);
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
 
-      expect(response.body).toEqual({
-        message: "ユーザー名の入力は必須です。",
-      });
-    });
-    it("【registerUserSchemaに基づくInvalidErrorのテスト】nameプロパティ有り・入力値(1文字以上)がない場合。", async () => {
-      const request = {
-        name: "",
-        password: "dummyPassword",
-        email: "dummyData@mail.com",
-      };
-
-      const response = await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.BAD_REQUEST,
-      }).send(request);
-
-      expect(response.body).toEqual({
-        message: "ユーザー名は1文字以上である必要があります。",
-      });
-    });
-    it("【registerUserSchemaに基づくInvalidErrorのテスト】passwordプロパティの入力値がない場合。", async () => {
-      const request = {
-        name: "ダミーユーザー",
-        email: "dummyData@mail.com",
-      };
-
-      const response = await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.BAD_REQUEST,
-      }).send(request);
-
-      expect(response.body).toEqual({
-        message: "パスワードの入力は必須です。",
-      });
-    });
-    it("【registerUserSchemaに基づくInvalidErrorのテスト】passwordプロパティ有り・入力値が不正(7文字以下)な場合。", async () => {
-      const request = {
-        name: "ダミーユーザー",
-        password: "Invalid",
-        email: "dummyData@mail.com",
-      };
-
-      const response = await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.BAD_REQUEST,
-      }).send(request);
-
-      expect(response.body).toEqual({
-        message: "パスワードは8文字以上である必要があります。",
-      });
-    });
-    it("【registerUserSchemaに基づくInvalidErrorのテスト】passwordプロパティ有り・入力値が不正(16文字より多い場合)な場合。", async () => {
-      const request = {
-        name: "ダミーユーザー",
-        password: "ExcessivePassword",
-        email: "dummyData@mail.com",
-      };
-
-      const response = await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.BAD_REQUEST,
-      }).send(request);
-
-      expect(response.body).toEqual({
-        message: "パスワードは16文字以下である必要があります。",
-      });
-    });
-    it("【registerUserSchemaに基づくInvalidErrorのテスト】emailプロパティの入力値がない場合。", async () => {
-      const request = {
-        name: "ダミーユーザー",
-        password: "dummyPassword",
-      };
-
-      const response = await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.BAD_REQUEST,
-      }).send(request);
-
-      expect(response.body).toEqual({
-        message: "emailの入力は必須です。",
-      });
-    });
-    it("【registerUserSchemaに基づくInvalidErrorのテスト】emailプロパティ有り・入力値が不正(形式が正しくない)な場合。", async () => {
-      const request = {
-        name: "ダミーユーザー",
-        password: "dummyPassword",
-        email: "incorrectFormat.com",
-      };
-
-      const response = await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.BAD_REQUEST,
-      }).send(request);
-
-      expect(response.body).toEqual({
-        message: "emailの形式が正しくありません。",
-      });
-    });
-    it("【ConflictErrorのテスト】email値が重複している場合。", async () => {
-      const request = {
-        name: "ダミーユーザー",
-        password: "dummyPassword",
-        email: "dummyData@mail.com",
-      };
-
-      await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.OK,
-      }).send(request);
-
-      const response = await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.CONFLICT,
-      }).send(request);
-
-      expect(response.body).toEqual({
-        message: "emailの内容が重複しています。",
-      });
-    });
-    it("プログラムの意図しないエラー(サーバー側の問題等)は、エラーメッセージとstatus(InternalServerError=500)が返る。", async () => {
-      jest
-        .spyOn(UserRepository.prototype, "register")
-        .mockImplementation(() => {
-          throw new Error("Unexpected Error");
+        expect(response.body).toEqual({
+          message: "ユーザー名の入力は必須です。",
         });
+      });
+      it("nameプロパティ有り・入力値(1文字以上)がない場合。", async () => {
+        const request = {
+          name: "",
+          password: "dummyPassword",
+          email: "dummyData@mail.com",
+        };
 
-      const request = {
-        name: "ダミーユーザー",
-        password: "dummyPassword",
-        email: "dummyData@mail.com",
-      };
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
 
-      const response = await requestAPI({
-        method: "post",
-        endPoint: "/api/todos/register",
-        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-      }).send(request);
+        expect(response.body).toEqual({
+          message: "ユーザー名は1文字以上である必要があります。",
+        });
+      });
+      it("passwordプロパティの入力値がない場合。", async () => {
+        const request = {
+          name: "ダミーユーザー",
+          email: "dummyData@mail.com",
+        };
 
-      expect(response.body).toEqual({ message: "Internal Server Error" });
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "パスワードの入力は必須です。",
+        });
+      });
+      it("passwordプロパティ有り・入力値が不正(7文字以下)な場合。", async () => {
+        const request = {
+          name: "ダミーユーザー",
+          password: "Invalid",
+          email: "dummyData@mail.com",
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "パスワードは8文字以上である必要があります。",
+        });
+      });
+      it("passwordプロパティ有り・入力値が不正(16文字より多い場合)な場合。", async () => {
+        const request = {
+          name: "ダミーユーザー",
+          password: "ExcessivePassword",
+          email: "dummyData@mail.com",
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "パスワードは16文字以下である必要があります。",
+        });
+      });
+      it("emailプロパティの入力値がない場合。", async () => {
+        const request = {
+          name: "ダミーユーザー",
+          password: "dummyPassword",
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "emailの入力は必須です。",
+        });
+      });
+      it("emailプロパティ有り・入力値が不正(形式が正しくない)な場合。", async () => {
+        const request = {
+          name: "ダミーユーザー",
+          password: "dummyPassword",
+          email: "incorrectFormat.com",
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "emailの形式が正しくありません。",
+        });
+      });
+    });
+    describe("【DBに関わるエラーテスト】", () => {
+      it("【ConflictErrorのテスト】email値が重複している場合。", async () => {
+        const request = {
+          name: "ダミーユーザー",
+          password: "dummyPassword",
+          email: "dummyData@mail.com",
+        };
+
+        await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.OK,
+        }).send(request);
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.CONFLICT,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "emailの内容が重複しています。",
+        });
+      });
+    });
+    describe("【サーバーに関わるエラーテスト】", () => {
+      it("プログラムの意図しないエラー(サーバー側の問題等)は、エラーメッセージとstatus(InternalServerError=500)が返る。", async () => {
+        jest
+          .spyOn(UserRepository.prototype, "register")
+          .mockImplementation(() => {
+            throw new Error("Unexpected Error");
+          });
+
+        const request = {
+          name: "ダミーユーザー",
+          password: "dummyPassword",
+          email: "dummyData@mail.com",
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        }).send(request);
+
+        expect(response.body).toEqual({ message: "Internal Server Error" });
+      });
     });
   });
 });

--- a/src/__test__/repositories/UserRepository.spec.ts
+++ b/src/__test__/repositories/UserRepository.spec.ts
@@ -74,7 +74,7 @@ describe("【UserRepositoryのテスト】", () => {
           password: "dummyPassword",
           email: "dummyData@mail.com",
         }),
-      ).rejects.toThrow("Unique constraint failed on the fields: (`email`)");
+      ).rejects.toThrow("emailの内容が重複しています。");
     });
     it("【loginメソッド実行時】存在しないユーザーを指定した場合、エラーオブジェクトが返る。", async () => {
       const repository = new UserRepository();

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,14 +2,15 @@ import cookieParser from "cookie-parser";
 import express from "express";
 
 import { errorHandler } from "./middlewares/errorHandler";
-import router from "./routers/todos";
+import todoRouter from "./routers/todos";
+import userRouter from "./routers/users";
 
 const app = express();
 app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-app.use("/api/todos", router);
+app.use("/api/todos", todoRouter, userRouter);
 app.use(errorHandler);
 
 export default app;

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,8 @@ app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-app.use("/api/todos", todoRouter, userRouter);
+app.use("/api/users", userRouter);
+app.use("/api/todos", todoRouter);
 app.use(errorHandler);
 
 export default app;

--- a/src/errors/ConflictError.ts
+++ b/src/errors/ConflictError.ts
@@ -1,0 +1,10 @@
+import { StatusCodes } from "http-status-codes";
+
+export class ConflictError extends Error {
+  statusCode: StatusCodes.CONFLICT;
+
+  constructor(message: string) {
+    super(message);
+    this.statusCode = StatusCodes.CONFLICT;
+  }
+}

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,6 +1,7 @@
 import type { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 
+import { ConflictError } from "../errors/ConflictError";
 import { InvalidError } from "../errors/InvalidError";
 import { NotFoundError } from "../errors/NotFoundError";
 import { UnauthorizedError } from "../errors/UnauthorizedError";
@@ -15,7 +16,8 @@ export function errorHandler(
   if (
     err instanceof InvalidError ||
     err instanceof NotFoundError ||
-    err instanceof UnauthorizedError
+    err instanceof UnauthorizedError ||
+    err instanceof ConflictError
   ) {
     res.status(err.statusCode).json({ message: err.message });
   } else {

--- a/src/routers/todos.ts
+++ b/src/routers/todos.ts
@@ -13,7 +13,7 @@ import { createTodoSchema } from "../schemas/todos/createTodoSchema";
 import { getTodosSchema } from "../schemas/todos/getTodosSchema";
 import { updateTodoSchema } from "../schemas/todos/updateTodoSchema";
 
-const router = express.Router();
+const todoRouter = express.Router();
 
 const todoRepository = new TodoRepository();
 const todoCreateController = new CreateTodoController(todoRepository);
@@ -22,7 +22,7 @@ const todoGetController = new GetTodoController(todoRepository);
 const todoUpdateController = new UpdateTodoController(todoRepository);
 const todoDeleteController = new DeleteTodoController(todoRepository);
 
-router
+todoRouter
   .route("/")
   .post(authHandler, validator(createTodoSchema), (req, res, next) => {
     todoCreateController.create(req, res, next);
@@ -31,7 +31,7 @@ router
     todosGetController.list(req, res, next);
   });
 
-router
+todoRouter
   .route("/:id")
   .get(authHandler, validator(requestIdSchema), (req, res, next) => {
     todoGetController.find(req, res, next);
@@ -43,4 +43,4 @@ router
     todoDeleteController.delete(req, res, next);
   });
 
-export default router;
+export default todoRouter;

--- a/src/routers/users.ts
+++ b/src/routers/users.ts
@@ -1,0 +1,19 @@
+import express from "express";
+
+import { RegisterUserController } from "../controllers/users/RegisterUserController";
+import { validator } from "../middlewares/validateHandler";
+import { UserRepository } from "../repositories/users/UserRepository";
+import { registerUserSchema } from "../schemas/users/registerUserSchema";
+
+const userRouter = express.Router();
+
+const userRepository = new UserRepository();
+const userRegisterController = new RegisterUserController(userRepository);
+
+userRouter
+  .route("/register")
+  .post(validator(registerUserSchema), (req, res, next) => {
+    userRegisterController.register(req, res, next);
+  });
+
+export default userRouter;


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

新規ユーザーの登録機能に関わる、
ルーティングの設定、結合テスト
の実装を行いました。

ルーティングの設定は、
TodosとUsersに分け、
Usersにユーザー関連の
設定をまとめるように修正を行いました。
![スクリーンショット 2024-10-24 173531](https://github.com/user-attachments/assets/8536557e-c58a-473d-9964-d7a18662b7c3)
![スクリーンショット 2024-10-24 173543](https://github.com/user-attachments/assets/ba014919-a727-412c-9190-9811adf57963)


結合テストについては、
成功パターン一つと、
バリデーションschemaに基づく
エラーテストならびにプリズマで
発生するエラー(emailの重複)テストを
行いました。

emailの重複については、
カスタムエラー(ConflictErrorを作成)で
エラーハンドリングするように、リポジトリの
修正(トライキャッチで、PrismaClientKnownRequestErrorをConflictErrorに変換)
を行いました。

よろしくお願いします。
