### PR TITLE
【ログイン機能】～ルーティングの設定とAPIテストの実装～

### DIFF
--- a/src/__test__/app/api/users/LoginUserController.spec.ts
+++ b/src/__test__/app/api/users/LoginUserController.spec.ts
@@ -1,0 +1,139 @@
+import { StatusCodes } from "http-status-codes";
+
+import { type User } from "@prisma/client";
+
+import { UserRepository } from "../../../../repositories/users/UserRepository";
+import { createTestUser, requestAPI } from "../../../helper/requestHelper";
+
+describe("【APIテスト】ユーザーログイン機能", () => {
+  let newUser: User;
+  beforeEach(async () => {
+    newUser = await createTestUser();
+  });
+  describe("【成功パターン】", () => {
+    it("password・emailをパラメーターに、認証に成功すればログインできる。", async () => {
+      const request = {
+        password: "dummyPassword",
+        email: newUser.email,
+      };
+
+      const response = await requestAPI({
+        method: "post",
+        endPoint: "/api/users/login",
+        statusCode: StatusCodes.OK,
+      }).send(request);
+
+      const responseUser = response.body;
+      const cookie = response.header["set-cookie"];
+
+      expect(responseUser).toEqual({
+        id: 1,
+        name: "ダミーユーザー",
+        email: newUser.email,
+      });
+      expect(cookie[0]).toContain("token=");
+    });
+  });
+  describe("【異常パターン】", () => {
+    describe("【loginUserSchemaに基づくInvalidErrorのテスト】", () => {
+      it("passwordプロパティの入力値がない場合。", async () => {
+        const request = {
+          email: newUser.email,
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/login",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "パスワードの入力は必須です。",
+        });
+      });
+      it("passwordプロパティ有り・入力値が不正(7文字以下)な場合。", async () => {
+        const request = {
+          password: "Invalid",
+          email: newUser.email,
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/login",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "パスワードは8文字以上である必要があります。",
+        });
+      });
+      it("passwordプロパティ有り・入力値が不正(16文字より多い場合)な場合。", async () => {
+        const request = {
+          password: "ExcessivePassword",
+          email: newUser.email,
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/login",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "パスワードは16文字以下である必要があります。",
+        });
+      });
+      it("emailプロパティの入力値がない場合。", async () => {
+        const request = {
+          password: "dummyPassword",
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/login",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "emailの入力は必須です。",
+        });
+      });
+      it("emailプロパティ有り・入力値が不正(形式が正しくない)な場合。", async () => {
+        const request = {
+          password: "dummyPassword",
+          email: "incorrectFormat.com",
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/login",
+          statusCode: StatusCodes.BAD_REQUEST,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "emailの形式が正しくありません。",
+        });
+      });
+    });
+    describe("【サーバーに関わるエラーテスト】", () => {
+      it("プログラムの意図しないエラー(サーバー側の問題等)は、エラーメッセージとstatus(InternalServerError=500)が返る。", async () => {
+        jest.spyOn(UserRepository.prototype, "login").mockImplementation(() => {
+          throw new Error("Unexpected Error");
+        });
+
+        const request = {
+          password: "dummyPassword",
+          email: newUser.email,
+        };
+
+        const response = await requestAPI({
+          method: "post",
+          endPoint: "/api/users/login",
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        }).send(request);
+
+        expect(response.body).toEqual({ message: "Internal Server Error" });
+      });
+    });
+  });
+});

--- a/src/routers/users.ts
+++ b/src/routers/users.ts
@@ -1,19 +1,28 @@
 import express from "express";
 
+import { LoginUserController } from "../controllers/users/LoginUserController";
 import { RegisterUserController } from "../controllers/users/RegisterUserController";
 import { validator } from "../middlewares/validateHandler";
 import { UserRepository } from "../repositories/users/UserRepository";
+import { loginUserSchema } from "../schemas/users/loginUserSchema";
 import { registerUserSchema } from "../schemas/users/registerUserSchema";
 
 const userRouter = express.Router();
 
 const userRepository = new UserRepository();
 const userRegisterController = new RegisterUserController(userRepository);
+const userLoginController = new LoginUserController(userRepository);
 
 userRouter
   .route("/register")
   .post(validator(registerUserSchema), (req, res, next) => {
     userRegisterController.register(req, res, next);
+  });
+
+userRouter
+  .route("/login")
+  .post(validator(loginUserSchema), (req, res, next) => {
+    userLoginController.login(req, res, next);
   });
 
 export default userRouter;

--- a/src/schemas/users/loginUserSchema.ts
+++ b/src/schemas/users/loginUserSchema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+import { emailPasswordSchema } from "./shared/emailPasswordSchema";
+
+export const loginUserSchema = z.object({
+  body: z.object({
+    ...emailPasswordSchema.shape,
+  }),
+});

--- a/src/schemas/users/loginUserSchema.ts
+++ b/src/schemas/users/loginUserSchema.ts
@@ -3,7 +3,5 @@ import { z } from "zod";
 import { emailPasswordSchema } from "./shared/emailPasswordSchema";
 
 export const loginUserSchema = z.object({
-  body: z.object({
-    ...emailPasswordSchema.shape,
-  }),
+  body: emailPasswordSchema,
 });


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

前回のプルリクで作成した異常パターンを
ほぼ踏襲し、成功パターン以外はほぼ同じ内容で
実装を行いました。

スキーマの設定ですが、
ルーティングで共通処理のschema(emailPasswordSchema)を
使用していましたが、結合テストでは、 z.objectの中で
bodyプロパティを必要(todoの時と同様の対応)とされました。

こちらの対応に関しては、
loginUserSchemaを作成し、この中にemailPasswordSchemaを
設定する形をとりました。

よろしくお願いします。


