### PR TITLE
【ユーザー情報の更新機能】～リポジトリの設定とテスト～

### DIFF
--- a/src/__test__/repositories/UserRepository.spec.ts
+++ b/src/__test__/repositories/UserRepository.spec.ts
@@ -1,6 +1,5 @@
 import bcrypt from "bcrypt";
 import jwt, { type JwtPayload } from "jsonwebtoken";
-import { userInfo } from "os";
 
 import { UserRepository } from "../../repositories/users/UserRepository";
 import { createTestUser } from "../helper/requestHelper";

--- a/src/__test__/repositories/UserRepository.spec.ts
+++ b/src/__test__/repositories/UserRepository.spec.ts
@@ -57,7 +57,7 @@ describe("【UserRepositoryのテスト】", () => {
 
       expect(decodedToken.userId).toEqual(user.id);
     });
-    it("【updateメソッド実行時】DBのユーザー情報を更新し、ユーザー情報とトークンを返す。", async () => {
+    it("【updateメソッド実行時】DBのユーザー情報(nameプロパティの値)を更新し、更新情報を返す。", async () => {
       const userData = await createTestUser();
       const repository = new UserRepository();
 
@@ -65,30 +65,49 @@ describe("【UserRepositoryのテスト】", () => {
         userId: userData.id,
         name: "変更後のユーザー名",
       });
-      expect(updatedName.user.id).toEqual(1);
-      expect(updatedName.user.name).toEqual("変更後のユーザー名");
+      expect(updatedName.id).toEqual(1);
+      expect(updatedName.name).toEqual("変更後のユーザー名");
+    });
+    it("【updateメソッド実行時】DBのユーザー情報(emailプロパティの値)を更新し、更新情報を返す。", async () => {
+      const userData = await createTestUser();
+      const repository = new UserRepository();
 
       const updatedEmail = await repository.update({
         userId: userData.id,
         email: "updatedEmail@mail.com",
       });
-      expect(updatedEmail.user.id).toEqual(1);
-      expect(updatedEmail.user.email).toEqual("updatedEmail@mail.com");
+      expect(updatedEmail.id).toEqual(1);
+      expect(updatedEmail.email).toEqual("updatedEmail@mail.com");
+    });
+    it("【updateメソッド実行時】DBのユーザー情報(passwordプロパティの値)を更新し、更新情報を返す。", async () => {
+      const userData = await createTestUser();
+      const repository = new UserRepository();
 
       const updatedPassword = await repository.update({
         userId: userData.id,
         password: "updatedPassword",
       });
-      expect(updatedPassword.user.id).toEqual(1);
+      expect(updatedPassword.id).toEqual(1);
       expect(
-        await bcrypt.compare("updatedPassword", updatedPassword.user.password),
+        await bcrypt.compare("updatedPassword", updatedPassword.password),
       ).toEqual(true);
+    });
+    it("【updateメソッド実行時】DBのユーザー情報(すべてのプロパティの値)を更新し、更新情報を返す。", async () => {
+      const userData = await createTestUser();
+      const repository = new UserRepository();
 
-      const decodedToken = jwt.verify(
-        updatedPassword.token,
-        process.env.JWT_SECRET!,
-      );
-      expect(decodedToken).toMatchObject({ userId: updatedPassword.user.id });
+      const updatedUser = await repository.update({
+        userId: userData.id,
+        name: "変更後のユーザー名",
+        password: "updatedPassword",
+        email: "updatedEmail@mail.com",
+      });
+      expect(updatedUser.id).toEqual(1);
+      expect(updatedUser.name).toEqual("変更後のユーザー名");
+      expect(
+        await bcrypt.compare("updatedPassword", updatedUser.password),
+      ).toEqual(true);
+      expect(updatedUser.email).toEqual("updatedEmail@mail.com");
     });
   });
   describe("【異常パターン】", () => {

--- a/src/__test__/repositories/UserRepository.spec.ts
+++ b/src/__test__/repositories/UserRepository.spec.ts
@@ -61,35 +61,35 @@ describe("【UserRepositoryのテスト】", () => {
       const userData = await createTestUser();
       const repository = new UserRepository();
 
-      const updatedName = await repository.update({
+      const updatedUser = await repository.update({
         userId: userData.id,
         name: "変更後のユーザー名",
       });
-      expect(updatedName.id).toEqual(1);
-      expect(updatedName.name).toEqual("変更後のユーザー名");
+      expect(updatedUser.id).toEqual(1);
+      expect(updatedUser.name).toEqual("変更後のユーザー名");
     });
     it("【updateメソッド実行時】DBのユーザー情報(emailプロパティの値)を更新し、更新情報を返す。", async () => {
       const userData = await createTestUser();
       const repository = new UserRepository();
 
-      const updatedEmail = await repository.update({
+      const updatedUser = await repository.update({
         userId: userData.id,
         email: "updatedEmail@mail.com",
       });
-      expect(updatedEmail.id).toEqual(1);
-      expect(updatedEmail.email).toEqual("updatedEmail@mail.com");
+      expect(updatedUser.id).toEqual(1);
+      expect(updatedUser.email).toEqual("updatedEmail@mail.com");
     });
     it("【updateメソッド実行時】DBのユーザー情報(passwordプロパティの値)を更新し、更新情報を返す。", async () => {
       const userData = await createTestUser();
       const repository = new UserRepository();
 
-      const updatedPassword = await repository.update({
+      const updatedUser = await repository.update({
         userId: userData.id,
         password: "updatedPassword",
       });
-      expect(updatedPassword.id).toEqual(1);
+      expect(updatedUser.id).toEqual(1);
       expect(
-        await bcrypt.compare("updatedPassword", updatedPassword.password),
+        await bcrypt.compare("updatedPassword", updatedUser.password),
       ).toEqual(true);
     });
     it("【updateメソッド実行時】DBのユーザー情報(すべてのプロパティの値)を更新し、更新情報を返す。", async () => {

--- a/src/repositories/users/IUserRepository.ts
+++ b/src/repositories/users/IUserRepository.ts
@@ -11,5 +11,5 @@ export interface IUserRepository {
     inputData: UserRegisterInput,
   ): Promise<{ user: User; token: string }>;
   login(inputData: UserLoginInput): Promise<{ user: User; token: string }>;
-  update(inputData: UserUpdateInput): Promise<{ user: User; token: string }>;
+  update(inputData: UserUpdateInput): Promise<User>;
 }

--- a/src/repositories/users/IUserRepository.ts
+++ b/src/repositories/users/IUserRepository.ts
@@ -3,6 +3,7 @@ import { User } from "@prisma/client";
 import type {
   UserLoginInput,
   UserRegisterInput,
+  UserUpdateInput,
 } from "../../types/users/UserRequest.type";
 
 export interface IUserRepository {
@@ -10,4 +11,5 @@ export interface IUserRepository {
     inputData: UserRegisterInput,
   ): Promise<{ user: User; token: string }>;
   login(inputData: UserLoginInput): Promise<{ user: User; token: string }>;
+  update(inputData: UserUpdateInput): Promise<{ user: User; token: string }>;
 }

--- a/src/repositories/users/UserRepository.ts
+++ b/src/repositories/users/UserRepository.ts
@@ -96,9 +96,7 @@ export class UserRepository {
         data: updateItems,
       });
 
-      const token = createJWT(updatedUser.id);
-
-      return { user: updatedUser, token };
+      return updatedUser;
     } catch (error) {
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/src/types/users/UserRequest.type.ts
+++ b/src/types/users/UserRequest.type.ts
@@ -10,12 +10,8 @@ export interface UserLoginInput {
 }
 
 export interface UserUpdateInput {
-  userId?: number;
+  userId: number;
   name?: string;
   password?: string;
   email?: string;
 }
-// export interface UserUpdateInput extends UserRegisterInput {
-//   userId: number;
-// }
-// Partial<User>

--- a/src/types/users/UserRequest.type.ts
+++ b/src/types/users/UserRequest.type.ts
@@ -8,3 +8,14 @@ export interface UserLoginInput {
   password: string;
   email: string;
 }
+
+export interface UserUpdateInput {
+  userId?: number;
+  name?: string;
+  password?: string;
+  email?: string;
+}
+// export interface UserUpdateInput extends UserRegisterInput {
+//   userId: number;
+// }
+// Partial<User>


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

今回はユーザー情報の
更新機能の実装を行いました。

更新機能はオプショナルなので、
Partialで型を設定し、用意した空オブジェクトに
更新データを格納する形をとりました。
![スクリーンショット 2024-10-28 235054](https://github.com/user-attachments/assets/e9b6d75b-85f6-469e-af61-554ae10c3678)
![スクリーンショット 2024-10-28 235125](https://github.com/user-attachments/assets/eddcdbd1-7cfc-427c-9e91-ffb020b25b13)

エラーハンドリングについては、
idなどは認証済ユーザーを前提と
しているんで、ガード節を
付加せず、emailの重複のみのエラーハンドリング
としました。

テストについては、
it内で各プロパティ値の更新を
確認するようにしました。

よろしくお願いします。
