### PR TITLE
【ユーザー情報の更新機能】コントローラーの設定(ユニットテストとvalidationスキーマの設定・テスト含む)

### DIFF
--- a/src/__test__/controllers/users/UpdateUserController.spec.ts
+++ b/src/__test__/controllers/users/UpdateUserController.spec.ts
@@ -149,9 +149,9 @@ describe("【ユニットテスト】ユーザー更新機能", () => {
           id: 1,
         },
         body: {
-          name: "InvalidName",
-          password: "InvalidPassword",
-          email: "InvalidEmail",
+          name: "",
+          password: "ExcessivePassword",
+          email: "incorrectFormat.com",
         },
       });
       const res = createMockResponse();

--- a/src/__test__/controllers/users/UpdateUserController.spec.ts
+++ b/src/__test__/controllers/users/UpdateUserController.spec.ts
@@ -1,0 +1,167 @@
+import { StatusCodes } from "http-status-codes";
+
+import { UpdateUserController } from "../../../controllers/users/UpdateUserController";
+import { MockRepository } from "../../helper/mocks/MockUserRepository";
+import { createMockAuthenticatedRequest } from "../../helper/mocks/request";
+import { createMockResponse } from "../../helper/mocks/response";
+
+describe("【ユニットテスト】ユーザー更新機能", () => {
+  let repository: MockRepository;
+  let controller: UpdateUserController;
+  beforeEach(async () => {
+    repository = new MockRepository();
+    controller = new UpdateUserController(repository);
+  });
+  describe("【成功パターン】", () => {
+    it("updateメソッドのパラメーターが【id:1とname:変更後のユーザー名】で呼び出され、更新後のデータが返る。", async () => {
+      const req = createMockAuthenticatedRequest({
+        user: {
+          id: 1,
+        },
+        body: {
+          name: "変更後のユーザー名",
+        },
+      });
+      const res = createMockResponse();
+      const next = jest.fn();
+
+      repository.update.mockResolvedValue({
+        id: 1,
+        name: "変更後のユーザー名",
+        email: "dummyData@mail.com",
+      });
+
+      await controller.update(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(StatusCodes.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 1,
+        name: "変更後のユーザー名",
+        email: "dummyData@mail.com",
+      });
+      expect(repository.update).toHaveBeenCalledWith({
+        userId: 1,
+        name: "変更後のユーザー名",
+      });
+    });
+    it("updateメソッドのパラメーターが【id:1とpassword:updatedPassword】で呼び出され、更新後のデータが返る。", async () => {
+      const req = createMockAuthenticatedRequest({
+        user: {
+          id: 1,
+        },
+        body: {
+          password: "updatedPassword",
+        },
+      });
+      const res = createMockResponse();
+      const next = jest.fn();
+
+      repository.update.mockResolvedValue({
+        id: 1,
+        name: "ダミーユーザー",
+        email: "dummyData@mail.com",
+      });
+
+      await controller.update(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(StatusCodes.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 1,
+        name: "ダミーユーザー",
+        email: "dummyData@mail.com",
+      });
+      expect(repository.update).toHaveBeenCalledWith({
+        userId: 1,
+        password: "updatedPassword",
+      });
+    });
+    it("updateメソッドのパラメーターが【id:1とemail:updatedEmail@mail.com】で呼び出され、更新後のデータが返る。", async () => {
+      const req = createMockAuthenticatedRequest({
+        user: {
+          id: 1,
+        },
+        body: {
+          email: "updatedEmail@mail.com",
+        },
+      });
+      const res = createMockResponse();
+      const next = jest.fn();
+
+      repository.update.mockResolvedValue({
+        id: 1,
+        name: "ダミーユーザー",
+        email: "updatedEmail@mail.com",
+      });
+
+      await controller.update(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(StatusCodes.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 1,
+        name: "ダミーユーザー",
+        email: "updatedEmail@mail.com",
+      });
+      expect(repository.update).toHaveBeenCalledWith({
+        userId: 1,
+        email: "updatedEmail@mail.com",
+      });
+    });
+    it("updateメソッドのパラメーターが【全てのプロパティの更新値】で呼び出され、更新後のデータが返る。", async () => {
+      const req = createMockAuthenticatedRequest({
+        user: {
+          id: 1,
+        },
+        body: {
+          name: "変更後のユーザー名",
+          password: "updatedPassword",
+          email: "updatedEmail@mail.com",
+        },
+      });
+      const res = createMockResponse();
+      const next = jest.fn();
+
+      repository.update.mockResolvedValue({
+        id: 1,
+        name: "変更後のユーザー名",
+        email: "updatedEmail@mail.com",
+      });
+
+      await controller.update(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(StatusCodes.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        id: 1,
+        name: "変更後のユーザー名",
+        email: "updatedEmail@mail.com",
+      });
+      expect(repository.update).toHaveBeenCalledWith({
+        userId: 1,
+        name: "変更後のユーザー名",
+        password: "updatedPassword",
+        email: "updatedEmail@mail.com",
+      });
+    });
+  });
+  describe("【異常パターン】", () => {
+    it("updateメソッドのパラメータが不正の場合、next関数(パラメーターがError)を実行する。", async () => {
+      const req = createMockAuthenticatedRequest({
+        user: {
+          id: 1,
+        },
+        body: {
+          name: "InvalidName",
+          password: "InvalidPassword",
+          email: "InvalidEmail",
+        },
+      });
+      const res = createMockResponse();
+      const next = jest.fn();
+
+      repository.update.mockRejectedValue(new Error("dummy error"));
+
+      await controller.update(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+});

--- a/src/__test__/helper/mocks/MockUserRepository.ts
+++ b/src/__test__/helper/mocks/MockUserRepository.ts
@@ -4,6 +4,7 @@ import type { IUserRepository } from "../../../repositories/users/IUserRepositor
 import type {
   UserLoginInput,
   UserRegisterInput,
+  UserUpdateInput,
 } from "../../../types/users/UserRequest.type";
 
 export class MockRepository implements IUserRepository {
@@ -12,4 +13,5 @@ export class MockRepository implements IUserRepository {
     [UserRegisterInput]
   >();
   login = jest.fn<Promise<{ user: User; token: string }>, [UserLoginInput]>();
+  update = jest.fn<Promise<Partial<User>>, [UserUpdateInput]>();
 }

--- a/src/controllers/users/UpdateUserController.ts
+++ b/src/controllers/users/UpdateUserController.ts
@@ -1,0 +1,33 @@
+import type { NextFunction, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+
+import { IUserRepository } from "../../repositories/users/IUserRepository";
+import { AuthenticatedRequest } from "../../types/requests/AuthenticatedRequest.type";
+
+export class UpdateUserController {
+  private repository: IUserRepository;
+  constructor(repository: IUserRepository) {
+    this.repository = repository;
+  }
+
+  async update(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+    try {
+      const { name, password, email } = req.body;
+      const userId = req.user?.id as number;
+      const user = await this.repository.update({
+        userId,
+        name,
+        password,
+        email,
+      });
+
+      res.status(StatusCodes.OK).json({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/src/controllers/users/UpdateUserController.ts
+++ b/src/controllers/users/UpdateUserController.ts
@@ -1,8 +1,8 @@
 import type { NextFunction, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 
-import { IUserRepository } from "../../repositories/users/IUserRepository";
-import { AuthenticatedRequest } from "../../types/requests/AuthenticatedRequest.type";
+import type { IUserRepository } from "../../repositories/users/IUserRepository";
+import type { AuthenticatedRequest } from "../../types/requests/AuthenticatedRequest.type";
 
 export class UpdateUserController {
   private repository: IUserRepository;

--- a/src/repositories/users/IUserRepository.ts
+++ b/src/repositories/users/IUserRepository.ts
@@ -11,5 +11,5 @@ export interface IUserRepository {
     inputData: UserRegisterInput,
   ): Promise<{ user: User; token: string }>;
   login(inputData: UserLoginInput): Promise<{ user: User; token: string }>;
-  update(inputData: UserUpdateInput): Promise<User>;
+  update(inputData: UserUpdateInput): Promise<Partial<User>>;
 }

--- a/src/routers/users.ts
+++ b/src/routers/users.ts
@@ -8,17 +8,21 @@ import { loginUserSchema } from "../schemas/users/loginUserSchema";
 import { registerUserSchema } from "../schemas/users/registerUserSchema";
 
 const userRouter = express.Router();
+
 const userRepository = new UserRepository();
 const userRegisterController = new RegisterUserController(userRepository);
 const userLoginController = new LoginUserController(userRepository);
+
 userRouter
   .route("/register")
   .post(validator(registerUserSchema), (req, res, next) => {
     userRegisterController.register(req, res, next);
   });
+
 userRouter
   .route("/login")
   .post(validator(loginUserSchema), (req, res, next) => {
     userLoginController.login(req, res, next);
   });
+
 export default userRouter;

--- a/src/routers/users.ts
+++ b/src/routers/users.ts
@@ -8,21 +8,17 @@ import { loginUserSchema } from "../schemas/users/loginUserSchema";
 import { registerUserSchema } from "../schemas/users/registerUserSchema";
 
 const userRouter = express.Router();
-
 const userRepository = new UserRepository();
 const userRegisterController = new RegisterUserController(userRepository);
 const userLoginController = new LoginUserController(userRepository);
-
 userRouter
   .route("/register")
   .post(validator(registerUserSchema), (req, res, next) => {
     userRegisterController.register(req, res, next);
   });
-
 userRouter
   .route("/login")
   .post(validator(loginUserSchema), (req, res, next) => {
     userLoginController.login(req, res, next);
   });
-
 export default userRouter;

--- a/src/schemas/users/updateUserSchema.ts
+++ b/src/schemas/users/updateUserSchema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const updateUserSchema = z.object({
+  body: z.object({
+    name: z
+      .string({ required_error: "ユーザー名の入力は必須です。" })
+      .min(1, "ユーザー名は1文字以上である必要があります。")
+      .optional(),
+    password: z
+      .string({ required_error: "パスワードの入力は必須です。" })
+      .min(8, "パスワードは8文字以上である必要があります。")
+      .max(16, "パスワードは16文字以下である必要があります。")
+      .optional(),
+    email: z
+      .string({ required_error: "emailの入力は必須です。" })
+      .email("emailの形式が正しくありません。")
+      .optional(),
+  }),
+});

--- a/src/schemas/users/updateUserSchema.ts
+++ b/src/schemas/users/updateUserSchema.ts
@@ -3,17 +3,14 @@ import { z } from "zod";
 export const updateUserSchema = z.object({
   body: z.object({
     name: z
-      .string({ required_error: "ユーザー名の入力は必須です。" })
+      .string()
       .min(1, "ユーザー名は1文字以上である必要があります。")
       .optional(),
     password: z
-      .string({ required_error: "パスワードの入力は必須です。" })
+      .string()
       .min(8, "パスワードは8文字以上である必要があります。")
       .max(16, "パスワードは16文字以下である必要があります。")
       .optional(),
-    email: z
-      .string({ required_error: "emailの入力は必須です。" })
-      .email("emailの形式が正しくありません。")
-      .optional(),
+    email: z.string().email("emailの形式が正しくありません。").optional(),
   }),
 });


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

コントローラーのテストは、
今回もユニットテストのみです。

スキーマの設定は、
実装済みのname、password、emailのschemaを
オプショナルにし、アップデートschemaで設定し直しました。

よろしくお願いします。



