### PR TITLE
【ユーザー情報の更新機能】～ルーティングの設定とAPIテストの実装～

### DIFF
--- a/src/__test__/app/api/users/UpdateUserController.spec.ts
+++ b/src/__test__/app/api/users/UpdateUserController.spec.ts
@@ -19,7 +19,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/register",
+        endPoint: "/api/users/update",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -37,7 +37,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/register",
+        endPoint: "/api/users/update",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -55,7 +55,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/register",
+        endPoint: "/api/users/update",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -75,7 +75,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/register",
+        endPoint: "/api/users/update",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -96,7 +96,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/register",
+          endPoint: "/api/users/update",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -112,7 +112,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/register",
+          endPoint: "/api/users/update",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -128,7 +128,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/register",
+          endPoint: "/api/users/update",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -144,7 +144,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/register",
+          endPoint: "/api/users/update",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -164,7 +164,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPI({
           method: "put",
-          endPoint: "/api/users/register",
+          endPoint: "/api/users/update",
           statusCode: StatusCodes.UNAUTHORIZED,
         }).send(request);
 
@@ -175,20 +175,14 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
     });
     describe("【DBに関わるエラーテスト】", () => {
       it("【ConflictErrorのテスト】email値が重複している場合。", async () => {
-        const repository = new UserRepository();
-
-        await repository.register({
-          name: "ダミーユーザー",
-          password: "dummyPassword",
-          email: "dummyData@mail.com",
-        });
+        const secondUser = await createTestUser();
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/register",
+          endPoint: "/api/users/update",
           statusCode: StatusCodes.CONFLICT,
-          userId: newUser.id,
-        }).send({ email: "dummyData@mail.com" });
+          userId: secondUser.id,
+        }).send({ email: newUser.email });
 
         expect(response.body).toEqual({
           message: "emailの内容が重複しています。",
@@ -211,7 +205,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/register",
+          endPoint: "/api/users/update",
           statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
           userId: newUser.id,
         }).send(request);

--- a/src/__test__/app/api/users/UpdateUserController.spec.ts
+++ b/src/__test__/app/api/users/UpdateUserController.spec.ts
@@ -1,0 +1,223 @@
+import { StatusCodes } from "http-status-codes";
+
+import { User } from "@prisma/client";
+
+import { UserRepository } from "../../../../repositories/users/UserRepository";
+import { requestAPI, requestAPIWithAuth } from "../../../helper/requestHelper";
+import { createTestUser } from "../../../helper/requestHelper";
+
+describe("【APIテスト】 ユーザーの更新機能", () => {
+  let newUser: User;
+  beforeEach(async () => {
+    newUser = await createTestUser();
+  });
+  describe("【成功パターン】", () => {
+    it("【nameプロパティの更新値】を送ったら成功する。", async () => {
+      const request = {
+        name: "変更後のユーザー名",
+      };
+
+      const response = await requestAPIWithAuth({
+        method: "put",
+        endPoint: "/api/users/register",
+        statusCode: StatusCodes.OK,
+        userId: newUser.id,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        id: newUser.id,
+        name: "変更後のユーザー名",
+        email: newUser.email,
+      });
+    });
+    it("【passwordプロパティの更新値】を送ったら成功する。", async () => {
+      const request = {
+        password: "updatedPassword",
+      };
+
+      const response = await requestAPIWithAuth({
+        method: "put",
+        endPoint: "/api/users/register",
+        statusCode: StatusCodes.OK,
+        userId: newUser.id,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        id: newUser.id,
+        name: "ダミーユーザー",
+        email: newUser.email,
+      });
+    });
+    it("【emailプロパティの更新値】を送ったら成功する。", async () => {
+      const request = {
+        email: "updatedEmail@mail.com",
+      };
+
+      const response = await requestAPIWithAuth({
+        method: "put",
+        endPoint: "/api/users/register",
+        statusCode: StatusCodes.OK,
+        userId: newUser.id,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        id: newUser.id,
+        name: "ダミーユーザー",
+        email: "updatedEmail@mail.com",
+      });
+    });
+    it("【全てのプロパティの更新値】を送ったら成功する。", async () => {
+      const request = {
+        name: "変更後のユーザー名",
+        password: "updatedPassword",
+        email: "updatedEmail@mail.com",
+      };
+
+      const response = await requestAPIWithAuth({
+        method: "put",
+        endPoint: "/api/users/register",
+        statusCode: StatusCodes.OK,
+        userId: newUser.id,
+      }).send(request);
+
+      expect(response.body).toEqual({
+        id: newUser.id,
+        name: "変更後のユーザー名",
+        email: "updatedEmail@mail.com",
+      });
+    });
+  });
+  describe("【異常パターン】", () => {
+    describe("【updateUserSchemaに基づくInvalidErrorのテスト】", () => {
+      it("nameプロパティの入力値(1文字以上)がない場合。", async () => {
+        const request = {
+          name: "",
+        };
+
+        const response = await requestAPIWithAuth({
+          method: "put",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+          userId: newUser.id,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "ユーザー名は1文字以上である必要があります。",
+        });
+      });
+      it("passwordプロパティの入力値が不正(7文字以下)な場合。", async () => {
+        const request = {
+          password: "Invalid",
+        };
+
+        const response = await requestAPIWithAuth({
+          method: "put",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+          userId: newUser.id,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "パスワードは8文字以上である必要があります。",
+        });
+      });
+      it("passwordプロパティの入力値が不正(16文字より多い場合)な場合。", async () => {
+        const request = {
+          password: "ExcessivePassword",
+        };
+
+        const response = await requestAPIWithAuth({
+          method: "put",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+          userId: newUser.id,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "パスワードは16文字以下である必要があります。",
+        });
+      });
+      it("emailプロパティの入力値が不正(形式が正しくない)な場合。", async () => {
+        const request = {
+          email: "incorrectFormat.com",
+        };
+
+        const response = await requestAPIWithAuth({
+          method: "put",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.BAD_REQUEST,
+          userId: newUser.id,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "emailの形式が正しくありません。",
+        });
+      });
+    });
+    describe("【認証に関わるエラーテスト】", () => {
+      it("【認証ユーザーでない場合】エラーメッセージとstatus(UNAUTHORIZED=401)が返る。", async () => {
+        const request = {
+          name: "変更後のユーザー名",
+          password: "updatedPassword",
+          email: "updatedEmail@mail.com",
+        };
+
+        const response = await requestAPI({
+          method: "put",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.UNAUTHORIZED,
+        }).send(request);
+
+        expect(response.body).toEqual({
+          message: "認証に失敗しました。",
+        });
+      });
+    });
+    describe("【DBに関わるエラーテスト】", () => {
+      it("【ConflictErrorのテスト】email値が重複している場合。", async () => {
+        const repository = new UserRepository();
+
+        await repository.register({
+          name: "ダミーユーザー",
+          password: "dummyPassword",
+          email: "dummyData@mail.com",
+        });
+
+        const response = await requestAPIWithAuth({
+          method: "put",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.CONFLICT,
+          userId: newUser.id,
+        }).send({ email: "dummyData@mail.com" });
+
+        expect(response.body).toEqual({
+          message: "emailの内容が重複しています。",
+        });
+      });
+    });
+    describe("【サーバーに関わるエラーテスト】", () => {
+      it("プログラムの意図しないエラー(サーバー側の問題等)は、エラーメッセージとstatus(InternalServerError=500)が返る。", async () => {
+        jest
+          .spyOn(UserRepository.prototype, "update")
+          .mockImplementation(() => {
+            throw new Error("Unexpected Error");
+          });
+
+        const request = {
+          name: "変更後のユーザー名",
+          password: "updatedPassword",
+          email: "updatedEmail@mail.com",
+        };
+
+        const response = await requestAPIWithAuth({
+          method: "put",
+          endPoint: "/api/users/register",
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          userId: newUser.id,
+        }).send(request);
+
+        expect(response.body).toEqual({ message: "Internal Server Error" });
+      });
+    });
+  });
+});

--- a/src/__test__/app/api/users/UpdateUserController.spec.ts
+++ b/src/__test__/app/api/users/UpdateUserController.spec.ts
@@ -19,7 +19,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/",
+        endPoint: "/api/users",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -37,7 +37,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/",
+        endPoint: "/api/users",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -55,7 +55,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/",
+        endPoint: "/api/users",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -75,7 +75,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/",
+        endPoint: "/api/users",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -96,7 +96,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/",
+          endPoint: "/api/users",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -112,7 +112,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/",
+          endPoint: "/api/users",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -128,7 +128,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/",
+          endPoint: "/api/users",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -144,7 +144,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/",
+          endPoint: "/api/users",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -164,7 +164,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPI({
           method: "put",
-          endPoint: "/api/users/",
+          endPoint: "/api/users",
           statusCode: StatusCodes.UNAUTHORIZED,
         }).send(request);
 
@@ -179,7 +179,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/",
+          endPoint: "/api/users",
           statusCode: StatusCodes.CONFLICT,
           userId: secondUser.id,
         }).send({ email: newUser.email });
@@ -205,7 +205,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/",
+          endPoint: "/api/users",
           statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
           userId: newUser.id,
         }).send(request);

--- a/src/__test__/app/api/users/UpdateUserController.spec.ts
+++ b/src/__test__/app/api/users/UpdateUserController.spec.ts
@@ -19,7 +19,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/update",
+        endPoint: "/api/users/",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -37,7 +37,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/update",
+        endPoint: "/api/users/",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -55,7 +55,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/update",
+        endPoint: "/api/users/",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -75,7 +75,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
       const response = await requestAPIWithAuth({
         method: "put",
-        endPoint: "/api/users/update",
+        endPoint: "/api/users/",
         statusCode: StatusCodes.OK,
         userId: newUser.id,
       }).send(request);
@@ -96,7 +96,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/update",
+          endPoint: "/api/users/",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -112,7 +112,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/update",
+          endPoint: "/api/users/",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -128,7 +128,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/update",
+          endPoint: "/api/users/",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -144,7 +144,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/update",
+          endPoint: "/api/users/",
           statusCode: StatusCodes.BAD_REQUEST,
           userId: newUser.id,
         }).send(request);
@@ -164,7 +164,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPI({
           method: "put",
-          endPoint: "/api/users/update",
+          endPoint: "/api/users/",
           statusCode: StatusCodes.UNAUTHORIZED,
         }).send(request);
 
@@ -179,7 +179,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/update",
+          endPoint: "/api/users/",
           statusCode: StatusCodes.CONFLICT,
           userId: secondUser.id,
         }).send({ email: newUser.email });
@@ -205,7 +205,7 @@ describe("【APIテスト】 ユーザーの更新機能", () => {
 
         const response = await requestAPIWithAuth({
           method: "put",
-          endPoint: "/api/users/update",
+          endPoint: "/api/users/",
           statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
           userId: newUser.id,
         }).send(request);

--- a/src/routers/users.ts
+++ b/src/routers/users.ts
@@ -30,7 +30,7 @@ userRouter
   });
 
 userRouter
-  .route("/update")
+  .route("/")
   .put(authHandler, validator(updateUserSchema), (req, res, next) => {
     updateController.update(req, res, next);
   });

--- a/src/routers/users.ts
+++ b/src/routers/users.ts
@@ -2,21 +2,28 @@ import express from "express";
 
 import { LoginUserController } from "../controllers/users/LoginUserController";
 import { RegisterUserController } from "../controllers/users/RegisterUserController";
+import { UpdateUserController } from "../controllers/users/UpdateUserController";
+import { authHandler } from "../middlewares/authHandler";
 import { validator } from "../middlewares/validateHandler";
 import { UserRepository } from "../repositories/users/UserRepository";
 import { loginUserSchema } from "../schemas/users/loginUserSchema";
 import { registerUserSchema } from "../schemas/users/registerUserSchema";
+import { updateUserSchema } from "../schemas/users/updateUserSchema";
 
 const userRouter = express.Router();
 
 const userRepository = new UserRepository();
 const userRegisterController = new RegisterUserController(userRepository);
 const userLoginController = new LoginUserController(userRepository);
+const updateController = new UpdateUserController(userRepository);
 
 userRouter
   .route("/register")
   .post(validator(registerUserSchema), (req, res, next) => {
     userRegisterController.register(req, res, next);
+  })
+  .put(authHandler, validator(updateUserSchema), (req, res, next) => {
+    updateController.update(req, res, next);
   });
 
 userRouter

--- a/src/routers/users.ts
+++ b/src/routers/users.ts
@@ -21,15 +21,18 @@ userRouter
   .route("/register")
   .post(validator(registerUserSchema), (req, res, next) => {
     userRegisterController.register(req, res, next);
-  })
-  .put(authHandler, validator(updateUserSchema), (req, res, next) => {
-    updateController.update(req, res, next);
   });
 
 userRouter
   .route("/login")
   .post(validator(loginUserSchema), (req, res, next) => {
     userLoginController.login(req, res, next);
+  });
+
+userRouter
+  .route("/update")
+  .put(authHandler, validator(updateUserSchema), (req, res, next) => {
+    updateController.update(req, res, next);
   });
 
 export default userRouter;


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

ルーティングに認証ハンドラーとスキーマを
設定し、ユーザーIDを使いまわす事ができるよう、
Todoと同様の設定を行いました。

結合テストの成功パターンは、ユニットテストと同様に
各プロパティ(name、password、email)と
全てのプロパティの更新値をリクエストし、
更新後のユーザー情報がレスポンスされるか
確認がとれるよう実装しました。

異常パターンは、４つにグルーピングし、
(InvalidError、認証エラー、DBに関わるエラー、サーバーに関わるエラー)
各エラーがレスポンスされるかを確認ができるよう実装しました。

よろしくお願いします。