### PR TITLE
【ユーザーの削除機能】～リポジトリの設定とテスト～

### DIFF
--- a/src/repositories/users/IUserRepository.ts
+++ b/src/repositories/users/IUserRepository.ts
@@ -1,6 +1,7 @@
 import { User } from "@prisma/client";
 
 import type {
+  UserDeleteInput,
   UserLoginInput,
   UserRegisterInput,
   UserUpdateInput,
@@ -12,4 +13,5 @@ export interface IUserRepository {
   ): Promise<{ user: User; token: string }>;
   login(inputData: UserLoginInput): Promise<{ user: User; token: string }>;
   update(inputData: UserUpdateInput): Promise<Partial<User>>;
+  delete(inputData: UserDeleteInput): Promise<User>;
 }

--- a/src/repositories/users/UserRepository.ts
+++ b/src/repositories/users/UserRepository.ts
@@ -10,6 +10,7 @@ import { InternalServerError } from "../../errors/InternalServerError";
 import { NotFoundError } from "../../errors/NotFoundError";
 import { UnauthorizedError } from "../../errors/UnauthorizedError";
 import type {
+  UserDeleteInput,
   UserLoginInput,
   UserRegisterInput,
   UserUpdateInput,
@@ -103,6 +104,25 @@ export class UserRepository {
         error.code === "P2002"
       ) {
         throw new ConflictError("emailの内容が重複しています。");
+      } else {
+        throw new InternalServerError("データベースにエラーが発生しました。");
+      }
+    }
+  }
+
+  async delete(inputData: UserDeleteInput) {
+    try {
+      const deletedUser = await prisma.user.delete({
+        where: { id: inputData.userId },
+      });
+
+      return deletedUser;
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        throw new NotFoundError("削除対象のユーザーが見つかりません。");
       } else {
         throw new InternalServerError("データベースにエラーが発生しました。");
       }

--- a/src/types/users/UserRequest.type.ts
+++ b/src/types/users/UserRequest.type.ts
@@ -15,3 +15,7 @@ export interface UserUpdateInput {
   password?: string;
   email?: string;
 }
+
+export interface UserDeleteInput {
+  userId: number;
+}


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

deleteメソッドの実装は、
トライキャッチで行いました。

成功した場合は、
削除したユーザー情報をレスポンスし、
失敗した場合は、
プリズマエラーをカスタムエラー(NotFoundError)で
レスポンスするようにしました。

テストに関しては、
成功パターンでは削除したユーザー情報の
確認と、検索後にユーザーが存在しない(null)事を
確認しました。

異常パターンは、
ユーザーID999で
NotFoundErrorの
確認が出来るようにしました。

よろしくお願いします。

