### PR TITLE
【フロントエンド実装】ログアウトページと機能実装

### DIFF
--- a/frontend/src/__test__/features/users/stores/reducers/authExtraReducer.spec.ts
+++ b/frontend/src/__test__/features/users/stores/reducers/authExtraReducer.spec.ts
@@ -27,7 +27,7 @@ describe("【ユニットテスト】State操作に関わるReducer関数(ユー
     expect(state.inProgress).toEqual(true);
     expect(state.error).toEqual(null);
   });
-  it("fulfilledReducer関数を実行すると、isSucceedをtrueにし、user情報の更新をする。", () => {
+  it("fulfilledReducer関数を実行すると、user情報の更新をする。", () => {
     const signupFulfilled = createAction<AuthResponse>("signup/fulfilled");
     const action = signupFulfilled({
       user: {

--- a/frontend/src/__test__/features/users/stores/reducers/authExtraReducer.spec.ts
+++ b/frontend/src/__test__/features/users/stores/reducers/authExtraReducer.spec.ts
@@ -5,6 +5,7 @@ import {
   pendingReducer,
   fulfilledReducer,
   rejectedReducer,
+  signoutFulfilledReducer,
 } from "@/features/users/stores/reducers/authExtraReducer";
 import type { AuthState, AuthResponse } from "@/features/users/types/authTypes";
 
@@ -14,6 +15,7 @@ describe("【ユニットテスト】State操作に関わるReducer関数(ユー
     state = {
       inProgress: false,
       isSucceeded: false,
+      isSignedOut: false,
       error: null,
       user: {
         name: "",
@@ -56,5 +58,13 @@ describe("【ユニットテスト】State操作に関わるReducer関数(ユー
     expect(state.inProgress).toEqual(false);
     expect(state.isSucceeded).toEqual(false);
     expect(state.error?.message).toEqual("dummyMessage");
+  });
+  it("signoutFulfilledReducer関数を実行すると、isSignedOutをtrueにする。", () => {
+    signoutFulfilledReducer(state);
+
+    expect(state.inProgress).toEqual(false);
+    expect(state.isSucceeded).toEqual(false);
+    expect(state.isSignedOut).toEqual(true);
+    expect(state.error).toEqual(null);
   });
 });

--- a/frontend/src/__test__/features/users/stores/reducers/authExtraReducer.spec.ts
+++ b/frontend/src/__test__/features/users/stores/reducers/authExtraReducer.spec.ts
@@ -15,7 +15,6 @@ describe("【ユニットテスト】State操作に関わるReducer関数(ユー
     state = {
       inProgress: false,
       isSucceeded: false,
-      isSignedOut: false,
       error: null,
       user: {
         name: "",
@@ -44,8 +43,8 @@ describe("【ユニットテスト】State操作に関わるReducer関数(ユー
     expect(state.inProgress).toEqual(false);
     expect(state.isSucceeded).toEqual(true);
     expect(state.error).toEqual(null);
-    expect(state.user.name).toEqual("ダミーユーザー");
-    expect(state.user.email).toEqual("dummyData@mail.com");
+    expect(state.user?.name).toEqual("ダミーユーザー");
+    expect(state.user?.email).toEqual("dummyData@mail.com");
   });
   it("rejectedReducer関数を実行すると、error情報の更新をする。", () => {
     const signupRejected = createAction<{ error: SerializedError }>(
@@ -59,12 +58,12 @@ describe("【ユニットテスト】State操作に関わるReducer関数(ユー
     expect(state.isSucceeded).toEqual(false);
     expect(state.error?.message).toEqual("dummyMessage");
   });
-  it("signoutFulfilledReducer関数を実行すると、isSignedOutをtrueにする。", () => {
+  it("signoutFulfilledReducer関数を実行すると、user情報をnullにする。", () => {
     signoutFulfilledReducer(state);
 
     expect(state.inProgress).toEqual(false);
     expect(state.isSucceeded).toEqual(false);
-    expect(state.isSignedOut).toEqual(true);
     expect(state.error).toEqual(null);
+    expect(state.user).toEqual(null);
   });
 });

--- a/frontend/src/__test__/features/users/stores/reducers/authExtraReducer.spec.ts
+++ b/frontend/src/__test__/features/users/stores/reducers/authExtraReducer.spec.ts
@@ -14,19 +14,17 @@ describe("【ユニットテスト】State操作に関わるReducer関数(ユー
   beforeEach(() => {
     state = {
       inProgress: false,
-      isSucceeded: false,
-      error: null,
       user: {
         name: "",
         email: "",
       },
+      error: null,
     };
   });
   it("pendingReducer関数を実行すると、inProgressをtrueにする。", () => {
     pendingReducer(state);
 
     expect(state.inProgress).toEqual(true);
-    expect(state.isSucceeded).toEqual(false);
     expect(state.error).toEqual(null);
   });
   it("fulfilledReducer関数を実行すると、isSucceedをtrueにし、user情報の更新をする。", () => {
@@ -41,10 +39,9 @@ describe("【ユニットテスト】State操作に関わるReducer関数(ユー
     fulfilledReducer(state, action);
 
     expect(state.inProgress).toEqual(false);
-    expect(state.isSucceeded).toEqual(true);
-    expect(state.error).toEqual(null);
     expect(state.user?.name).toEqual("ダミーユーザー");
     expect(state.user?.email).toEqual("dummyData@mail.com");
+    expect(state.error).toEqual(null);
   });
   it("rejectedReducer関数を実行すると、error情報の更新をする。", () => {
     const signupRejected = createAction<{ error: SerializedError }>(
@@ -55,15 +52,13 @@ describe("【ユニットテスト】State操作に関わるReducer関数(ユー
     rejectedReducer(state, action.payload);
 
     expect(state.inProgress).toEqual(false);
-    expect(state.isSucceeded).toEqual(false);
     expect(state.error?.message).toEqual("dummyMessage");
   });
   it("signoutFulfilledReducer関数を実行すると、user情報をnullにする。", () => {
     signoutFulfilledReducer(state);
 
     expect(state.inProgress).toEqual(false);
-    expect(state.isSucceeded).toEqual(false);
-    expect(state.error).toEqual(null);
     expect(state.user).toEqual(null);
+    expect(state.error).toEqual(null);
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -16,9 +16,5 @@ export default function TodoPage() {
       router.push("/signin");
     }
   }, [authState.user]);
-  return (
-    <>
-      <Header />;
-    </>
-  );
+  return <Header />;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,24 @@
+"use client";
+
 import React from "react";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+import { useAppSelector } from "@/stores/hooks";
 import Header from "@/components/shared/header";
 
 export default function TodoPage() {
-  return <Header />;
+  const router = useRouter();
+  const authState = useAppSelector((state) => state.auth);
+
+  useEffect(() => {
+    if (authState.user === null) {
+      router.push("/signin");
+    }
+  }, [authState.user]);
+  return (
+    <>
+      <Header />;
+    </>
+  );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,6 @@
 import React from "react";
+import Header from "@/components/shared/header";
 
 export default function TodoPage() {
-  return (
-    <div>
-      <h1>Todoページ</h1>
-    </div>
-  );
+  return <Header />;
 }

--- a/frontend/src/components/shared/header.tsx
+++ b/frontend/src/components/shared/header.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import type { MouseEventHandler, FC } from "react";
+import { useAppDispatch, useAppSelector } from "@/stores/hooks";
+import { createSignoutAction } from "@/features/users/stores/reducers/signoutReducer";
+
+const Header: FC = () => {
+  const router = useRouter();
+  const dispatch = useAppDispatch();
+  const signoutState = useAppSelector((state) => state.auth);
+
+  useEffect(() => {
+    if (signoutState.isSignedOut) {
+      router.push("/signin");
+    }
+  }, [signoutState.isSignedOut]);
+
+  const handleSubmit: MouseEventHandler<HTMLButtonElement> = async (event) => {
+    event.preventDefault();
+    dispatch(createSignoutAction());
+  };
+
+  if (signoutState.inProgress) {
+    return <p>送信中...</p>;
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-100">
+      <header className="bg-blue-500 text-white p-4 flex justify-between items-center">
+        <h1 className="text-xl font-bold">Todo App</h1>
+        <button
+          onClick={handleSubmit}
+          className="px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-md"
+        >
+          ログアウト
+        </button>
+      </header>
+    </div>
+  );
+};
+
+export default Header;

--- a/frontend/src/components/shared/header.tsx
+++ b/frontend/src/components/shared/header.tsx
@@ -9,20 +9,20 @@ import { createSignoutAction } from "@/features/users/stores/reducers/signoutRed
 const Header: FC = () => {
   const router = useRouter();
   const dispatch = useAppDispatch();
-  const signoutState = useAppSelector((state) => state.auth);
+  const authState = useAppSelector((state) => state.auth);
 
   useEffect(() => {
-    if (signoutState.isSignedOut) {
+    if (authState.user === null) {
       router.push("/signin");
     }
-  }, [signoutState.isSignedOut]);
+  }, [authState.user]);
 
   const handleSubmit: MouseEventHandler<HTMLButtonElement> = async (event) => {
     event.preventDefault();
     dispatch(createSignoutAction());
   };
 
-  if (signoutState.inProgress) {
+  if (authState.inProgress) {
     return <p>送信中...</p>;
   }
 

--- a/frontend/src/features/users/api/signout.ts
+++ b/frontend/src/features/users/api/signout.ts
@@ -1,0 +1,16 @@
+export const signoutApi = async () => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/users/logout`,
+    {
+      method: "POST",
+      credentials: "include",
+    }
+  );
+  if (!response.ok) {
+    const errorData = await response.json();
+
+    throw errorData;
+  }
+
+  return undefined;
+};

--- a/frontend/src/features/users/api/signout.ts
+++ b/frontend/src/features/users/api/signout.ts
@@ -11,6 +11,4 @@ export const signoutApi = async () => {
 
     throw errorData;
   }
-
-  return undefined;
 };

--- a/frontend/src/features/users/components/signinForm.tsx
+++ b/frontend/src/features/users/components/signinForm.tsx
@@ -15,10 +15,10 @@ const SigninForm: FC = () => {
   const authState = useAppSelector((state) => state.auth);
 
   useEffect(() => {
-    if (authState.isSucceeded) {
+    if (authState.user) {
       router.push("/");
     }
-  }, [authState.isSucceeded]);
+  }, [authState.user]);
 
   const [formData, setFormData] = useState<SigninInput>({
     email: "",

--- a/frontend/src/features/users/components/signinForm.tsx
+++ b/frontend/src/features/users/components/signinForm.tsx
@@ -12,13 +12,13 @@ import { SubmitButton } from "@/features/users/components/shared/submitButton";
 const SigninForm: FC = () => {
   const router = useRouter();
   const dispatch = useAppDispatch();
-  const signinState = useAppSelector((state) => state.auth);
+  const authState = useAppSelector((state) => state.auth);
 
   useEffect(() => {
-    if (signinState.isSucceeded) {
+    if (authState.isSucceeded) {
       router.push("/");
     }
-  }, [signinState.isSucceeded]);
+  }, [authState.isSucceeded]);
 
   const [formData, setFormData] = useState<SigninInput>({
     email: "",
@@ -37,12 +37,12 @@ const SigninForm: FC = () => {
     event.preventDefault();
     dispatch(createSigninAction(formData));
 
-    if (signinState.error) {
+    if (authState.error) {
       setFormData((formData) => ({ ...formData, password: "" }));
     }
   };
 
-  if (signinState.inProgress) {
+  if (authState.inProgress) {
     return <p>送信中...</p>;
   }
 
@@ -52,11 +52,11 @@ const SigninForm: FC = () => {
         <h2 className="text-2xl font-bold text-center text-gray-700">
           Sign In
         </h2>
-        {signinState.error?.message && (
+        {authState.error?.message && (
           <p className="text-center text-red-600">
-            {Array.isArray(signinState.error.message)
-              ? signinState.error.message.join(" ")
-              : signinState.error.message}
+            {Array.isArray(authState.error.message)
+              ? authState.error.message.join(" ")
+              : authState.error.message}
           </p>
         )}
 

--- a/frontend/src/features/users/components/signupForm.tsx
+++ b/frontend/src/features/users/components/signupForm.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import type { ChangeEventHandler, FormEventHandler, FC } from "react";
+
 import { useAppDispatch, useAppSelector } from "@/stores/hooks";
 import type { SignupInput } from "@/features/users/types/authTypes";
 import { createSignupAction } from "@/features/users/stores/reducers/signupReducer";
@@ -9,8 +11,15 @@ import { InputField } from "@/features/users/components/shared/inputField";
 import { SubmitButton } from "@/features/users/components/shared/submitButton";
 
 const SignupForm: FC = () => {
+  const router = useRouter();
   const dispatch = useAppDispatch();
   const authState = useAppSelector((state) => state.auth);
+
+  useEffect(() => {
+    if (authState.user) {
+      router.push("/");
+    }
+  }, [authState.user]);
 
   const [formData, setFormData] = useState<SignupInput>({
     name: "",
@@ -37,21 +46,6 @@ const SignupForm: FC = () => {
 
   if (authState.inProgress) {
     return <p>送信中...</p>;
-  }
-
-  if (authState.isSucceeded) {
-    return (
-      <div className="flex items-center justify-center min-h-screen bg-gray-100">
-        <div className="w-full max-w-md p-8 space-y-6 bg-white shadow-md rounded-md">
-          <h2 className="text-2xl font-bold text-center text-gray-700">
-            登録が完了しました!
-          </h2>
-          <p className="text-center text-gray-600">
-            ご登録ありがとうございます！サービスを利用する準備ができました。
-          </p>
-        </div>
-      </div>
-    );
   }
 
   return (

--- a/frontend/src/features/users/components/signupForm.tsx
+++ b/frontend/src/features/users/components/signupForm.tsx
@@ -10,7 +10,7 @@ import { SubmitButton } from "@/features/users/components/shared/submitButton";
 
 const SignupForm: FC = () => {
   const dispatch = useAppDispatch();
-  const signupState = useAppSelector((state) => state.auth);
+  const authState = useAppSelector((state) => state.auth);
 
   const [formData, setFormData] = useState<SignupInput>({
     name: "",
@@ -30,16 +30,16 @@ const SignupForm: FC = () => {
     event.preventDefault();
     dispatch(createSignupAction(formData));
 
-    if (signupState.error) {
+    if (authState.error) {
       setFormData((formData) => ({ ...formData, password: "" }));
     }
   };
 
-  if (signupState.inProgress) {
+  if (authState.inProgress) {
     return <p>送信中...</p>;
   }
 
-  if (signupState.isSucceeded) {
+  if (authState.isSucceeded) {
     return (
       <div className="flex items-center justify-center min-h-screen bg-gray-100">
         <div className="w-full max-w-md p-8 space-y-6 bg-white shadow-md rounded-md">
@@ -60,11 +60,11 @@ const SignupForm: FC = () => {
         <h2 className="text-2xl font-bold text-center text-gray-700">
           Sign Up
         </h2>
-        {signupState.error?.message && (
+        {authState.error?.message && (
           <p className="text-center text-red-600">
-            {Array.isArray(signupState.error.message)
-              ? signupState.error.message.join(" ")
-              : signupState.error.message}
+            {Array.isArray(authState.error.message)
+              ? authState.error.message.join(" ")
+              : authState.error.message}
           </p>
         )}
 

--- a/frontend/src/features/users/stores/authSlice.ts
+++ b/frontend/src/features/users/stores/authSlice.ts
@@ -2,11 +2,13 @@ import { createSlice } from "@reduxjs/toolkit";
 
 import { buildSignupExtraReducer } from "@/features/users/stores/reducers/signupReducer";
 import { buildSigninExtraReducer } from "@/features/users/stores/reducers/signinReducer";
+import { buildSignoutExtraReducer } from "@/features/users/stores/reducers/signoutReducer";
 import type { AuthState } from "@/features/users/types/authTypes";
 
 const initialState: AuthState = {
   inProgress: false,
   isSucceeded: false,
+  isSignedOut: false,
   error: null,
   user: {
     name: "",
@@ -21,6 +23,7 @@ export const authSlice = createSlice({
   extraReducers(builder) {
     buildSignupExtraReducer(builder);
     buildSigninExtraReducer(builder);
+    buildSignoutExtraReducer(builder);
   },
 });
 

--- a/frontend/src/features/users/stores/authSlice.ts
+++ b/frontend/src/features/users/stores/authSlice.ts
@@ -8,12 +8,8 @@ import type { AuthState } from "@/features/users/types/authTypes";
 const initialState: AuthState = {
   inProgress: false,
   isSucceeded: false,
-  isSignedOut: false,
   error: null,
-  user: {
-    name: "",
-    email: "",
-  },
+  user: null,
 };
 
 export const authSlice = createSlice({

--- a/frontend/src/features/users/stores/authSlice.ts
+++ b/frontend/src/features/users/stores/authSlice.ts
@@ -7,9 +7,8 @@ import type { AuthState } from "@/features/users/types/authTypes";
 
 const initialState: AuthState = {
   inProgress: false,
-  isSucceeded: false,
-  error: null,
   user: null,
+  error: null,
 };
 
 export const authSlice = createSlice({

--- a/frontend/src/features/users/stores/reducers/authExtraReducer.ts
+++ b/frontend/src/features/users/stores/reducers/authExtraReducer.ts
@@ -11,7 +11,6 @@ export const fulfilledReducer = (
   action: PayloadAction<AuthResponse>
 ) => {
   state.inProgress = false;
-  state.isSucceeded = true;
   state.error = null;
   if (action.payload.user) {
     state.user = {
@@ -23,9 +22,8 @@ export const fulfilledReducer = (
 
 export const signoutFulfilledReducer = (state: AuthState) => {
   state.inProgress = false;
-  state.isSucceeded = false;
-  state.error = null;
   state.user = null;
+  state.error = null;
 };
 
 export const rejectedReducer = (
@@ -35,7 +33,6 @@ export const rejectedReducer = (
   const message = action.error.message;
 
   state.inProgress = false;
-  state.isSucceeded = false;
   state.error = {
     message: message ?? "例外エラー",
   };

--- a/frontend/src/features/users/stores/reducers/authExtraReducer.ts
+++ b/frontend/src/features/users/stores/reducers/authExtraReducer.ts
@@ -12,7 +12,6 @@ export const fulfilledReducer = (
 ) => {
   state.inProgress = false;
   state.isSucceeded = true;
-  state.isSignedOut = false;
   state.error = null;
   if (action.payload.user) {
     state.user = {
@@ -25,8 +24,8 @@ export const fulfilledReducer = (
 export const signoutFulfilledReducer = (state: AuthState) => {
   state.inProgress = false;
   state.isSucceeded = false;
-  state.isSignedOut = true;
   state.error = null;
+  state.user = null;
 };
 
 export const rejectedReducer = (
@@ -37,7 +36,6 @@ export const rejectedReducer = (
 
   state.inProgress = false;
   state.isSucceeded = false;
-  state.isSignedOut = false;
   state.error = {
     message: message ?? "例外エラー",
   };

--- a/frontend/src/features/users/stores/reducers/authExtraReducer.ts
+++ b/frontend/src/features/users/stores/reducers/authExtraReducer.ts
@@ -10,9 +10,10 @@ export const fulfilledReducer = (
   state: AuthState,
   action: PayloadAction<AuthResponse>
 ) => {
-  state.error = null;
-  state.isSucceeded = true;
   state.inProgress = false;
+  state.isSucceeded = true;
+  state.isSignedOut = false;
+  state.error = null;
   if (action.payload.user) {
     state.user = {
       name: action.payload.user?.name,
@@ -21,14 +22,22 @@ export const fulfilledReducer = (
   }
 };
 
+export const signoutFulfilledReducer = (state: AuthState) => {
+  state.inProgress = false;
+  state.isSucceeded = false;
+  state.isSignedOut = true;
+  state.error = null;
+};
+
 export const rejectedReducer = (
   state: AuthState,
   action: { error: SerializedError }
 ) => {
   const message = action.error.message;
 
-  state.isSucceeded = false;
   state.inProgress = false;
+  state.isSucceeded = false;
+  state.isSignedOut = false;
   state.error = {
     message: message ?? "例外エラー",
   };

--- a/frontend/src/features/users/stores/reducers/signoutReducer.ts
+++ b/frontend/src/features/users/stores/reducers/signoutReducer.ts
@@ -1,0 +1,26 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import type { ActionReducerMapBuilder } from "@reduxjs/toolkit";
+
+import { signoutApi } from "@/features/users/api/signout";
+import {
+  pendingReducer,
+  signoutFulfilledReducer,
+  rejectedReducer,
+} from "@/features/users/stores/reducers/authExtraReducer";
+import type { AuthState } from "@/features/users/types/authTypes";
+
+export const createSignoutAction = createAsyncThunk(
+  "auth/signout",
+  async () => {
+    return signoutApi();
+  }
+);
+
+export const buildSignoutExtraReducer = (
+  builder: ActionReducerMapBuilder<AuthState>
+) => {
+  builder
+    .addCase(createSignoutAction.pending, pendingReducer)
+    .addCase(createSignoutAction.fulfilled, signoutFulfilledReducer)
+    .addCase(createSignoutAction.rejected, rejectedReducer);
+};

--- a/frontend/src/features/users/types/authTypes.ts
+++ b/frontend/src/features/users/types/authTypes.ts
@@ -1,6 +1,7 @@
 export interface AuthState {
   inProgress: boolean;
   isSucceeded: boolean;
+  isSignedOut: boolean;
   error: AuthResponseError | null;
   user: {
     name: string;

--- a/frontend/src/features/users/types/authTypes.ts
+++ b/frontend/src/features/users/types/authTypes.ts
@@ -5,9 +5,8 @@ interface User {
 
 export interface AuthState {
   inProgress: boolean;
-  isSucceeded: boolean;
-  error: AuthResponseError | null;
   user: User | null;
+  error: AuthResponseError | null;
 }
 
 export interface SigninInput {

--- a/frontend/src/features/users/types/authTypes.ts
+++ b/frontend/src/features/users/types/authTypes.ts
@@ -1,12 +1,13 @@
+interface User {
+  name: string;
+  email: string;
+}
+
 export interface AuthState {
   inProgress: boolean;
   isSucceeded: boolean;
-  isSignedOut: boolean;
   error: AuthResponseError | null;
-  user: {
-    name: string;
-    email: string;
-  };
+  user: User | null;
 }
 
 export interface SigninInput {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from "tailwindcss";
 
 export default {
   content: [
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/features/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1344,11 +1344,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "backend/node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "backend/node_modules/@eslint/eslintrc/node_modules/debug": {
       "version": "4.3.6",
       "dev": true,
@@ -1374,17 +1369,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "backend/node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "backend/node_modules/@eslint/eslintrc/node_modules/ms": {


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

・ディレクトリ構成について
src/components/sharedにヘッダー
を作成し、todo実装時にフッター等の
コンポーネントを配置するように
設置しました。

・ヘッダーに関して
Todoページにヘッダーを作成し、
ログアウトボタンを設置しました。

こちらのボタンを
押すと、ログインページにリダイレクト
するよう設定を行いました。

リダイレクトのフラグは、
リダックスのイニシャルステートに
新たなステート(isSignedOut)を
追加し、こちらで状態に応じた
ページ遷移が行えるようにしました。
![スクリーンショット 2024-12-19 234111](https://github.com/user-attachments/assets/ddd71d50-7306-45c1-a779-5368c4bb5839)

・reducersには
signoutFulfilledReducerを
追加し、こちらのユニットテストも
追加しました。
![スクリーンショット 2024-12-19 234507](https://github.com/user-attachments/assets/e2b0a5c8-d468-475f-ae45-fb496f834ed3)

よろしくお願いします。