### PR TITLE
【フロントエンド実装】Todo一覧ページと機能実装

### DIFF
--- a/frontend/src/__test__/features/todos/stores/reducers/todoExtraReducer.spec.ts
+++ b/frontend/src/__test__/features/todos/stores/reducers/todoExtraReducer.spec.ts
@@ -3,8 +3,8 @@ import type { SerializedError } from "@reduxjs/toolkit";
 
 import {
   pendingReducer,
-  addTodoFulfilledReducer,
-  addTodosFulfilledReducer,
+  createTodoFulfilledReducer,
+  getTodosFulfilledReducer,
   rejectedReducer,
 } from "@/features/todos/stores/reducers/todoExtraReducer";
 import type { TodoState, TodoResponse } from "@/features/todos/types/todoTypes";
@@ -14,7 +14,7 @@ describe("【ユニットテスト】State操作(TodoState)に関わるReducer�
   beforeEach(() => {
     state = {
       inProgress: false,
-      todos: [],
+      todoPage: { items: [], totalCount: 0 },
       error: null,
     };
   });
@@ -23,36 +23,16 @@ describe("【ユニットテスト】State操作(TodoState)に関わるReducer�
 
     expect(state.inProgress).toEqual(true);
   });
-  it("addTodoFulfilledReducer関数を実行すると、Stateのtodos配列にTodoを追加する。", () => {
-    const fulfilled = createAction<TodoResponse>("todo/createTodo");
-    const action = fulfilled({
-      todo: {
-        id: 1,
-        title: "ダミータイトル",
-        body: "ダミーボディ",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
-
-    addTodoFulfilledReducer(state, action);
+  it("createTodoFulfilledReducer関数を実行すると、inProgressをfalseにする。", () => {
+    createTodoFulfilledReducer(state);
 
     expect(state.inProgress).toEqual(false);
-    expect(state.todos).toEqual([
-      {
-        id: 1,
-        title: "ダミータイトル",
-        body: "ダミーボディ",
-        createdAt: action.payload.todo?.createdAt,
-        updatedAt: action.payload.todo?.updatedAt,
-      },
-    ]);
     expect(state.error).toEqual(null);
   });
-  it("addTodosFulfilledReducer関数を実行すると、Stateのtodos配列にTodos(配列)を追加する。", () => {
-    const fulfilled = createAction<TodoResponse>("todo/createTodo");
+  it("getTodosFulfilledReducer関数を実行すると、 todoPageのitemsとtotalCountにデータを追加する。", () => {
+    const fulfilled = createAction<TodoResponse>("todo/getTodos");
     const action = fulfilled({
-      todos: [
+      items: [
         {
           id: 1,
           title: "ダミータイトル1",
@@ -75,34 +55,36 @@ describe("【ユニットテスト】State操作(TodoState)に関わるReducer�
           updatedAt: new Date(),
         },
       ],
+      totalCount: 3,
     });
 
-    addTodosFulfilledReducer(state, action);
+    getTodosFulfilledReducer(state, action);
 
     expect(state.inProgress).toEqual(false);
-    expect(state.todos).toEqual([
+    expect(state.todoPage.items).toEqual([
       {
         id: 1,
         title: "ダミータイトル1",
         body: "ダミーボディ1",
-        createdAt: action.payload.todos?.map((todo) => todo.updatedAt)[0],
-        updatedAt: action.payload?.todos?.map((todo) => todo.updatedAt)[0],
+        createdAt: action.payload.items?.map((todo) => todo.updatedAt)[0],
+        updatedAt: action.payload?.items?.map((todo) => todo.updatedAt)[0],
       },
       {
         id: 2,
         title: "ダミータイトル2",
         body: "ダミーボディ2",
-        createdAt: action.payload?.todos?.map((todo) => todo.createdAt)[1],
-        updatedAt: action.payload?.todos?.map((todo) => todo.updatedAt)[1],
+        createdAt: action.payload?.items?.map((todo) => todo.createdAt)[1],
+        updatedAt: action.payload?.items?.map((todo) => todo.updatedAt)[1],
       },
       {
         id: 3,
         title: "ダミータイトル3",
         body: "ダミーボディ3",
-        createdAt: action.payload?.todos?.map((todo) => todo.createdAt)[2],
-        updatedAt: action.payload?.todos?.map((todo) => todo.updatedAt)[2],
+        createdAt: action.payload?.items?.map((todo) => todo.createdAt)[2],
+        updatedAt: action.payload?.items?.map((todo) => todo.updatedAt)[2],
       },
     ]);
+    expect(state.todoPage.totalCount).toEqual(3);
     expect(state.error).toEqual(null);
   });
   it("rejectedReducer関数を実行すると、error情報の更新をする。", () => {

--- a/frontend/src/__test__/features/todos/stores/reducers/todoExtraReducer.spec.ts
+++ b/frontend/src/__test__/features/todos/stores/reducers/todoExtraReducer.spec.ts
@@ -3,7 +3,8 @@ import type { SerializedError } from "@reduxjs/toolkit";
 
 import {
   pendingReducer,
-  fulfilledReducer,
+  addTodoFulfilledReducer,
+  addTodosFulfilledReducer,
   rejectedReducer,
 } from "@/features/todos/stores/reducers/todoExtraReducer";
 import type { TodoState, TodoResponse } from "@/features/todos/types/todoTypes";
@@ -22,7 +23,7 @@ describe("【ユニットテスト】State操作(TodoState)に関わるReducer�
 
     expect(state.inProgress).toEqual(true);
   });
-  it("fulfilledReducer関数を実行すると、todosの配列情報を更新をする。", () => {
+  it("addTodoFulfilledReducer関数を実行すると、Stateのtodos配列にTodoを追加する。", () => {
     const fulfilled = createAction<TodoResponse>("todo/createTodo");
     const action = fulfilled({
       todo: {
@@ -34,7 +35,7 @@ describe("【ユニットテスト】State操作(TodoState)に関わるReducer�
       },
     });
 
-    fulfilledReducer(state, action);
+    addTodoFulfilledReducer(state, action);
 
     expect(state.inProgress).toEqual(false);
     expect(state.todos).toEqual([
@@ -44,6 +45,62 @@ describe("【ユニットテスト】State操作(TodoState)に関わるReducer�
         body: "ダミーボディ",
         createdAt: action.payload.todo?.createdAt,
         updatedAt: action.payload.todo?.updatedAt,
+      },
+    ]);
+    expect(state.error).toEqual(null);
+  });
+  it("addTodosFulfilledReducer関数を実行すると、Stateのtodos配列にTodos(配列)を追加する。", () => {
+    const fulfilled = createAction<TodoResponse>("todo/createTodo");
+    const action = fulfilled({
+      todos: [
+        {
+          id: 1,
+          title: "ダミータイトル1",
+          body: "ダミーボディ1",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 2,
+          title: "ダミータイトル2",
+          body: "ダミーボディ2",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 3,
+          title: "ダミータイトル3",
+          body: "ダミーボディ3",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    });
+
+    addTodosFulfilledReducer(state, action);
+
+    expect(state.inProgress).toEqual(false);
+    expect(state.todos).toEqual([
+      {
+        id: 1,
+        title: "ダミータイトル1",
+        body: "ダミーボディ1",
+        createdAt: action.payload.todos?.map((todo) => todo.updatedAt)[0],
+        updatedAt: action.payload?.todos?.map((todo) => todo.updatedAt)[0],
+      },
+      {
+        id: 2,
+        title: "ダミータイトル2",
+        body: "ダミーボディ2",
+        createdAt: action.payload?.todos?.map((todo) => todo.createdAt)[1],
+        updatedAt: action.payload?.todos?.map((todo) => todo.updatedAt)[1],
+      },
+      {
+        id: 3,
+        title: "ダミータイトル3",
+        body: "ダミーボディ3",
+        createdAt: action.payload?.todos?.map((todo) => todo.createdAt)[2],
+        updatedAt: action.payload?.todos?.map((todo) => todo.updatedAt)[2],
       },
     ]);
     expect(state.error).toEqual(null);

--- a/frontend/src/app/(authenticated)/todos/page.tsx
+++ b/frontend/src/app/(authenticated)/todos/page.tsx
@@ -18,13 +18,12 @@ const TodosPage = () => {
   const [page, setPage] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const skip = (page - 1) * PAGE_SIZE;
-  const items = state.todoPage.items.slice(skip, skip + PAGE_SIZE);
+  const items = state.todoPage.items;
   const totalCount = state.todoPage.totalCount;
 
   useEffect(() => {
     dispatch(getTodosAction({ page }));
-  }, [page, totalCount]);
+  }, [page, isModalOpen]);
 
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);

--- a/frontend/src/app/(authenticated)/todos/page.tsx
+++ b/frontend/src/app/(authenticated)/todos/page.tsx
@@ -28,9 +28,6 @@ const TodosPage = () => {
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
 
-  const setNextPage = () => setPage((page) => page + 1);
-  const setPrevPage = () => setPage((page) => page - 1);
-
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-100 to-gray-100 p-6">
       <div className="max-w-4xl mx-auto bg-white rounded-lg shadow-lg p-8">
@@ -57,8 +54,6 @@ const TodosPage = () => {
       {totalCount > 0 && (
         <CreatePagination
           {...{ totalCount, PAGE_SIZE, page }}
-          onNextPage={() => setNextPage()}
-          onPrevPage={() => setPrevPage()}
           onChangePage={(ChangePage) => setPage(ChangePage)}
         />
       )}

--- a/frontend/src/app/(authenticated)/todos/page.tsx
+++ b/frontend/src/app/(authenticated)/todos/page.tsx
@@ -1,22 +1,33 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
-import { useAppSelector } from "@/stores/hooks";
-import { BlueButton } from "@/components/shared/buttons/buttons";
+import { useAppDispatch, useAppSelector } from "@/stores/hooks";
+import { BlueButton, GrayButton } from "@/components/shared/buttons/buttons";
 import CreateTodoModal from "@/features/todos/components/createTodoModal";
+import { getTodosAction } from "@/features/todos/stores/reducers/getTodosReducer";
+import TodoList from "@/features/todos/components/todoList";
 
 const TodosPage = () => {
-  const todos = useAppSelector((state) => state.todo.todos);
+  const dispatch = useAppDispatch();
+  const state = useAppSelector((state) => state.todo);
+
+  const [page, setPage] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const openModal = () => {
-    setIsModalOpen(true);
-  };
+  const take = 10;
+  const skip = (page - 1) * take;
+  const todos = state.todos.slice(skip, skip + take);
 
-  const closeModal = () => {
-    setIsModalOpen(false);
-  };
+  useEffect(() => {
+    dispatch(getTodosAction({ page }));
+  }, [page]);
+
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  const setNextPage = () => setPage((page) => page + 1);
+  const setPrevPage = () => setPage((page) => page - 1);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-100 to-gray-100 p-6">
@@ -27,17 +38,8 @@ const TodosPage = () => {
         <div className="flex justify-end mb-6 text-lg font-medium ">
           <BlueButton label="新規Todo" onClick={openModal} />
         </div>
-        <div className="space-y-6">
-          {todos.map((todo) => (
-            <div
-              key={todo.id}
-              className="p-6 border rounded-lg shadow-md hover:shadow-lg bg-white transform hover:scale-105 transition duration-300"
-            >
-              <h2 className="text-xl font-bold text-gray-700">{todo.title}</h2>
-              <p className="text-gray-600 mt-2 leading-relaxed">{todo.body}</p>
-            </div>
-          ))}
-        </div>
+        {/* Todoリスト */}
+        <TodoList todos={todos} />
       </div>
       {/* モーダル */}
       {isModalOpen && (
@@ -46,6 +48,20 @@ const TodosPage = () => {
           onCancel={() => closeModal()}
         />
       )}
+      {/* ページ選択 */}
+      <div className="flex items-center justify-center mt-6">
+        {page > 1 && (
+          <>
+            <GrayButton label="前のページ" onClick={setPrevPage} />
+            <span className="text-lg font-medium text-gray-600 mx-4">
+              ページ: {page}
+            </span>
+          </>
+        )}
+        {todos.length === take && (
+          <GrayButton label="次のページ" onClick={setNextPage} />
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/app/(authenticated)/todos/page.tsx
+++ b/frontend/src/app/(authenticated)/todos/page.tsx
@@ -8,6 +8,8 @@ import CreateTodoModal from "@/features/todos/components/createTodoModal";
 import { getTodosAction } from "@/features/todos/stores/reducers/getTodosReducer";
 import TodoList from "@/features/todos/components/todoList";
 
+const PAGE_SIZE = 10;
+
 const TodosPage = () => {
   const dispatch = useAppDispatch();
   const state = useAppSelector((state) => state.todo);
@@ -15,9 +17,8 @@ const TodosPage = () => {
   const [page, setPage] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const take = 10;
-  const skip = (page - 1) * take;
-  const todos = state.todos.slice(skip, skip + take);
+  const skip = (page - 1) * PAGE_SIZE;
+  const todos = state.todos.slice(skip, skip + PAGE_SIZE);
 
   useEffect(() => {
     dispatch(getTodosAction({ page }));
@@ -58,7 +59,7 @@ const TodosPage = () => {
             </span>
           </>
         )}
-        {todos.length === take && (
+        {todos.length === PAGE_SIZE && (
           <GrayButton label="次のページ" onClick={setNextPage} />
         )}
       </div>

--- a/frontend/src/app/(authenticated)/todos/page.tsx
+++ b/frontend/src/app/(authenticated)/todos/page.tsx
@@ -23,7 +23,7 @@ const TodosPage = () => {
 
   useEffect(() => {
     dispatch(getTodosAction({ page }));
-  }, [page, isModalOpen]);
+  }, [page]);
 
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
@@ -46,7 +46,10 @@ const TodosPage = () => {
       {/* モーダル */}
       {isModalOpen && (
         <CreateTodoModal
-          onCreateSuccess={() => closeModal()}
+          onCreateSuccess={() => {
+            closeModal();
+            dispatch(getTodosAction({ page }));
+          }}
           onCancel={() => closeModal()}
         />
       )}

--- a/frontend/src/app/(authenticated)/todos/page.tsx
+++ b/frontend/src/app/(authenticated)/todos/page.tsx
@@ -3,10 +3,11 @@
 import { useState, useEffect } from "react";
 
 import { useAppDispatch, useAppSelector } from "@/stores/hooks";
-import { BlueButton, GrayButton } from "@/components/shared/buttons/buttons";
+import { BlueButton } from "@/components/shared/buttons/buttons";
 import CreateTodoModal from "@/features/todos/components/createTodoModal";
 import { getTodosAction } from "@/features/todos/stores/reducers/getTodosReducer";
 import TodoList from "@/features/todos/components/todoList";
+import { CreatePagination } from "@/features/todos/components/createPagination";
 
 const PAGE_SIZE = 10;
 
@@ -18,11 +19,12 @@ const TodosPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const skip = (page - 1) * PAGE_SIZE;
-  const todos = state.todos.slice(skip, skip + PAGE_SIZE);
+  const items = state.todoPage.items.slice(skip, skip + PAGE_SIZE);
+  const totalCount = state.todoPage.totalCount;
 
   useEffect(() => {
     dispatch(getTodosAction({ page }));
-  }, [page]);
+  }, [page, totalCount]);
 
   const openModal = () => setIsModalOpen(true);
   const closeModal = () => setIsModalOpen(false);
@@ -40,7 +42,7 @@ const TodosPage = () => {
           <BlueButton label="新規Todo" onClick={openModal} />
         </div>
         {/* Todoリスト */}
-        <TodoList todos={todos} />
+        <TodoList todos={items} />
       </div>
       {/* モーダル */}
       {isModalOpen && (
@@ -49,20 +51,15 @@ const TodosPage = () => {
           onCancel={() => closeModal()}
         />
       )}
-      {/* ページ選択 */}
-      <div className="flex items-center justify-center mt-6">
-        {page > 1 && (
-          <>
-            <GrayButton label="前のページ" onClick={setPrevPage} />
-            <span className="text-lg font-medium text-gray-600 mx-4">
-              ページ: {page}
-            </span>
-          </>
-        )}
-        {todos.length === PAGE_SIZE && (
-          <GrayButton label="次のページ" onClick={setNextPage} />
-        )}
-      </div>
+      {/* ページネーション */}
+      {totalCount > 0 && (
+        <CreatePagination
+          {...{ totalCount, PAGE_SIZE, page }}
+          onNextPage={() => setNextPage()}
+          onPrevPage={() => setPrevPage()}
+          onChangePage={(ChangePage) => setPage(ChangePage)}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/shared/buttons/buttons.tsx
+++ b/frontend/src/components/shared/buttons/buttons.tsx
@@ -64,3 +64,15 @@ export const CloseButton: FC<ButtonProps> = ({ label, onClick }) => {
     </button>
   );
 };
+
+export const GrayButton: FC<ButtonProps> = ({ label, onClick }) => {
+  return (
+    <button
+      type="submit"
+      className="px-4 py-2 bg-gray-300 text-gray-700 rounded-lg hover:bg-gray-400"
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+};

--- a/frontend/src/components/shared/buttons/paginationButton.tsx
+++ b/frontend/src/components/shared/buttons/paginationButton.tsx
@@ -1,0 +1,24 @@
+import type { FC } from "react";
+
+interface ButtonProps {
+  label: number;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  page: number;
+  currentPage: number;
+}
+
+export const PaginationButton: FC<ButtonProps> = ({
+  label,
+  onClick,
+  page,
+  currentPage,
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-10 h-10 rounded ${page === currentPage ? "bg-blue-500 text-white" : "bg-gray-300 text-black hover:bg-gray-400"}`}
+    >
+      {label}
+    </button>
+  );
+};

--- a/frontend/src/features/todos/api/getTodos.ts
+++ b/frontend/src/features/todos/api/getTodos.ts
@@ -1,0 +1,26 @@
+import type {
+  TodoListParams,
+  TodoResponse,
+} from "@/features/todos/types/todoTypes";
+
+export const getTodosApi = async (
+  paramsData: TodoListParams
+): Promise<TodoResponse> => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/todos?page=${paramsData?.page}`,
+    {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      cache: "force-cache",
+    }
+  );
+  if (!response.ok) {
+    const errorData = await response.json();
+
+    throw errorData;
+  }
+  const todos = await response.json();
+
+  return { todo: todos };
+};

--- a/frontend/src/features/todos/api/getTodos.ts
+++ b/frontend/src/features/todos/api/getTodos.ts
@@ -7,12 +7,11 @@ export const getTodosApi = async (
   paramsData: TodoListParams
 ): Promise<TodoResponse> => {
   const response = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/todos?page=${paramsData?.page}`,
+    `${process.env.NEXT_PUBLIC_API_URL}/api/todos?page=${paramsData.page}`,
     {
       method: "GET",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
-      cache: "force-cache",
     }
   );
   if (!response.ok) {
@@ -20,7 +19,7 @@ export const getTodosApi = async (
 
     throw errorData;
   }
-  const todos = await response.json();
 
-  return { todo: todos };
+  const todos = await response.json();
+  return { todos };
 };

--- a/frontend/src/features/todos/api/getTodos.ts
+++ b/frontend/src/features/todos/api/getTodos.ts
@@ -19,7 +19,7 @@ export const getTodosApi = async (
 
     throw errorData;
   }
+  const pageResult = await response.json();
 
-  const todos = await response.json();
-  return { todos };
+  return pageResult;
 };

--- a/frontend/src/features/todos/components/createPagination.tsx
+++ b/frontend/src/features/todos/components/createPagination.tsx
@@ -21,6 +21,16 @@ export const CreatePagination: React.FC<PaginationProps> = ({
   const totalPages = Math.ceil(totalCount / PAGE_SIZE);
   const pages = [...Array(totalPages)].map((_, i) => i + 1);
 
+  const getPageItems = () => {
+    if (totalPages <= 10) return pages;
+    if (page <= 5) return [1, 2, 3, 4, 5, "...", totalPages];
+    if (page >= totalPages - 4) return [1, "...", ...pages.slice(-5)];
+
+    return [1, "...", page - 1, page, page + 1, "...", totalPages];
+  };
+
+  const pageItems = getPageItems() ?? [];
+
   return (
     <div className="flex justify-center mt-6 w-full">
       <div className="flex items-center justify-center space-x-2">
@@ -28,15 +38,24 @@ export const CreatePagination: React.FC<PaginationProps> = ({
         {page > 1 && <GrayButton label="前へ" onClick={onPrevPage} />}
         {/* ページネーションボタン */}
         <div className="flex justify-center space-x-2">
-          {pages.map((_page, index) => (
-            <PaginationButton
-              key={index}
-              label={_page}
-              page={_page}
-              currentPage={page}
-              onClick={() => onChangePage(_page)}
-            />
-          ))}
+          {pageItems.map((item, index) =>
+            item === "..." ? (
+              <span
+                key={index}
+                className="px-4 py-2 bg-gray-200 text-gray-600 rounded-md cursor-default"
+              >
+                ...
+              </span>
+            ) : (
+              <PaginationButton
+                key={index}
+                label={item as number}
+                page={item as number}
+                currentPage={page}
+                onClick={() => onChangePage(item as number)}
+              />
+            )
+          )}
         </div>
         {/* 次へボタン */}
         {page < totalPages && <GrayButton label="次へ" onClick={onNextPage} />}

--- a/frontend/src/features/todos/components/createPagination.tsx
+++ b/frontend/src/features/todos/components/createPagination.tsx
@@ -5,8 +5,6 @@ interface PaginationProps {
   totalCount: number;
   PAGE_SIZE: number;
   page: number;
-  onNextPage: () => void;
-  onPrevPage: () => void;
   onChangePage: (ChangePage: number) => void;
 }
 
@@ -14,8 +12,6 @@ export const CreatePagination: React.FC<PaginationProps> = ({
   totalCount,
   PAGE_SIZE,
   page,
-  onNextPage,
-  onPrevPage,
   onChangePage,
 }) => {
   const totalPage = Math.ceil(totalCount / PAGE_SIZE);
@@ -35,7 +31,9 @@ export const CreatePagination: React.FC<PaginationProps> = ({
     <div className="flex justify-center mt-6 w-full">
       <div className="flex items-center justify-center space-x-2">
         {/* 前へボタン */}
-        {page > 1 && <GrayButton label="前へ" onClick={onPrevPage} />}
+        {page > 1 && (
+          <GrayButton label="前へ" onClick={() => onChangePage(--page)} />
+        )}
         {/* ページネーションボタン */}
         <div className="flex justify-center space-x-2">
           {pageItems.map((item, index) =>
@@ -58,7 +56,9 @@ export const CreatePagination: React.FC<PaginationProps> = ({
           )}
         </div>
         {/* 次へボタン */}
-        {page < totalPage && <GrayButton label="次へ" onClick={onNextPage} />}
+        {page < totalPage && (
+          <GrayButton label="次へ" onClick={() => onChangePage(++page)} />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/features/todos/components/createPagination.tsx
+++ b/frontend/src/features/todos/components/createPagination.tsx
@@ -1,0 +1,46 @@
+import { GrayButton } from "@/components/shared/buttons/buttons";
+import { PaginationButton } from "@/components/shared/buttons/paginationButton";
+
+interface PaginationProps {
+  totalCount: number;
+  PAGE_SIZE: number;
+  page: number;
+  onNextPage: () => void;
+  onPrevPage: () => void;
+  onChangePage: (ChangePage: number) => void;
+}
+
+export const CreatePagination: React.FC<PaginationProps> = ({
+  totalCount,
+  PAGE_SIZE,
+  page,
+  onNextPage,
+  onPrevPage,
+  onChangePage,
+}) => {
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+  const pages = [...Array(totalPages)].map((_, i) => i + 1);
+
+  return (
+    <div className="flex justify-center mt-6 w-full">
+      <div className="flex items-center justify-center space-x-2">
+        {/* 前へボタン */}
+        {page > 1 && <GrayButton label="前へ" onClick={onPrevPage} />}
+        {/* ページネーションボタン */}
+        <div className="flex justify-center space-x-2">
+          {pages.map((_page, index) => (
+            <PaginationButton
+              key={index}
+              label={_page}
+              page={_page}
+              currentPage={page}
+              onClick={() => onChangePage(_page)}
+            />
+          ))}
+        </div>
+        {/* 次へボタン */}
+        {page < totalPages && <GrayButton label="次へ" onClick={onNextPage} />}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/features/todos/components/createPagination.tsx
+++ b/frontend/src/features/todos/components/createPagination.tsx
@@ -18,15 +18,15 @@ export const CreatePagination: React.FC<PaginationProps> = ({
   onPrevPage,
   onChangePage,
 }) => {
-  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
-  const pages = [...Array(totalPages)].map((_, i) => i + 1);
+  const totalPage = Math.ceil(totalCount / PAGE_SIZE);
+  const pages = [...Array(totalPage)].map((_, i) => i + 1);
 
   const getPageItems = () => {
-    if (totalPages <= 10) return pages;
-    if (page <= 5) return [1, 2, 3, 4, 5, "...", totalPages];
-    if (page >= totalPages - 4) return [1, "...", ...pages.slice(-5)];
+    if (totalPage <= 10) return pages;
+    if (page <= 5) return [1, 2, 3, 4, 5, "...", totalPage];
+    if (page >= totalPage - 4) return [1, "...", ...pages.slice(-5)];
 
-    return [1, "...", page - 1, page, page + 1, "...", totalPages];
+    return [1, "...", page - 1, page, page + 1, "...", totalPage];
   };
 
   const pageItems = getPageItems() ?? [];
@@ -58,7 +58,7 @@ export const CreatePagination: React.FC<PaginationProps> = ({
           )}
         </div>
         {/* 次へボタン */}
-        {page < totalPages && <GrayButton label="次へ" onClick={onNextPage} />}
+        {page < totalPage && <GrayButton label="次へ" onClick={onNextPage} />}
       </div>
     </div>
   );

--- a/frontend/src/features/todos/components/createTodoModal.tsx
+++ b/frontend/src/features/todos/components/createTodoModal.tsx
@@ -10,6 +10,7 @@ import { CloseButton } from "@/components/shared/buttons/buttons";
 import { createTodoAction } from "@/features/todos/stores/reducers/createTodoReducer";
 
 import type { TodoInput } from "@/features/todos/types/todoTypes";
+import { getTodosAction } from "../stores/reducers/getTodosReducer";
 
 interface ModalProps {
   onCreateSuccess: () => void;

--- a/frontend/src/features/todos/components/createTodoModal.tsx
+++ b/frontend/src/features/todos/components/createTodoModal.tsx
@@ -10,7 +10,6 @@ import { CloseButton } from "@/components/shared/buttons/buttons";
 import { createTodoAction } from "@/features/todos/stores/reducers/createTodoReducer";
 
 import type { TodoInput } from "@/features/todos/types/todoTypes";
-import { getTodosAction } from "../stores/reducers/getTodosReducer";
 
 interface ModalProps {
   onCreateSuccess: () => void;

--- a/frontend/src/features/todos/components/todoList.tsx
+++ b/frontend/src/features/todos/components/todoList.tsx
@@ -1,0 +1,18 @@
+import type { TodoListProps } from "@/features/todos/types/todoTypes";
+
+const TodoList: React.FC<TodoListProps> = ({ todos }) => {
+  return (
+    <div className="space-y-6">
+      {todos.map((todo) => (
+        <div
+          key={todo.id}
+          className="p-6 border rounded-lg shadow-md hover:shadow-lg bg-white transform hover:scale-105 transition duration-300"
+        >
+          <h2 className="text-xl font-bold text-gray-700">{todo.title}</h2>
+          <p className="text-gray-600 mt-2 leading-relaxed">{todo.body}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+export default TodoList;

--- a/frontend/src/features/todos/stores/reducers/createTodoReducer.ts
+++ b/frontend/src/features/todos/stores/reducers/createTodoReducer.ts
@@ -3,7 +3,7 @@ import type { ActionReducerMapBuilder } from "@reduxjs/toolkit";
 
 import {
   pendingReducer,
-  addTodoFulfilledReducer,
+  createTodoFulfilledReducer,
   rejectedReducer,
 } from "@/features/todos/stores/reducers/todoExtraReducer";
 import type {
@@ -25,6 +25,6 @@ export const buildCreateTodoExtraReducer = (
 ) => {
   builder
     .addCase(createTodoAction.pending, pendingReducer)
-    .addCase(createTodoAction.fulfilled, addTodoFulfilledReducer)
+    .addCase(createTodoAction.fulfilled, createTodoFulfilledReducer)
     .addCase(createTodoAction.rejected, rejectedReducer);
 };

--- a/frontend/src/features/todos/stores/reducers/createTodoReducer.ts
+++ b/frontend/src/features/todos/stores/reducers/createTodoReducer.ts
@@ -3,7 +3,7 @@ import type { ActionReducerMapBuilder } from "@reduxjs/toolkit";
 
 import {
   pendingReducer,
-  fulfilledReducer,
+  addTodoFulfilledReducer,
   rejectedReducer,
 } from "@/features/todos/stores/reducers/todoExtraReducer";
 import type {
@@ -25,6 +25,6 @@ export const buildCreateTodoExtraReducer = (
 ) => {
   builder
     .addCase(createTodoAction.pending, pendingReducer)
-    .addCase(createTodoAction.fulfilled, fulfilledReducer)
+    .addCase(createTodoAction.fulfilled, addTodoFulfilledReducer)
     .addCase(createTodoAction.rejected, rejectedReducer);
 };

--- a/frontend/src/features/todos/stores/reducers/getTodosReducer.ts
+++ b/frontend/src/features/todos/stores/reducers/getTodosReducer.ts
@@ -3,7 +3,7 @@ import type { ActionReducerMapBuilder } from "@reduxjs/toolkit";
 
 import {
   pendingReducer,
-  addTodosFulfilledReducer,
+  getTodosFulfilledReducer,
   rejectedReducer,
 } from "@/features/todos/stores/reducers/todoExtraReducer";
 import type {
@@ -25,6 +25,6 @@ export const buildGetTodosExtraReducer = (
 ) => {
   builder
     .addCase(getTodosAction.pending, pendingReducer)
-    .addCase(getTodosAction.fulfilled, addTodosFulfilledReducer)
+    .addCase(getTodosAction.fulfilled, getTodosFulfilledReducer)
     .addCase(getTodosAction.rejected, rejectedReducer);
 };

--- a/frontend/src/features/todos/stores/reducers/getTodosReducer.ts
+++ b/frontend/src/features/todos/stores/reducers/getTodosReducer.ts
@@ -3,7 +3,7 @@ import type { ActionReducerMapBuilder } from "@reduxjs/toolkit";
 
 import {
   pendingReducer,
-  fulfilledReducer,
+  addTodosFulfilledReducer,
   rejectedReducer,
 } from "@/features/todos/stores/reducers/todoExtraReducer";
 import type {
@@ -25,6 +25,6 @@ export const buildGetTodosExtraReducer = (
 ) => {
   builder
     .addCase(getTodosAction.pending, pendingReducer)
-    .addCase(getTodosAction.fulfilled, fulfilledReducer)
+    .addCase(getTodosAction.fulfilled, addTodosFulfilledReducer)
     .addCase(getTodosAction.rejected, rejectedReducer);
 };

--- a/frontend/src/features/todos/stores/reducers/getTodosReducer.ts
+++ b/frontend/src/features/todos/stores/reducers/getTodosReducer.ts
@@ -1,0 +1,30 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import type { ActionReducerMapBuilder } from "@reduxjs/toolkit";
+
+import {
+  pendingReducer,
+  fulfilledReducer,
+  rejectedReducer,
+} from "@/features/todos/stores/reducers/todoExtraReducer";
+import type {
+  TodoListParams,
+  TodoResponse,
+  TodoState,
+} from "@/features/todos/types/todoTypes";
+import { getTodosApi } from "@/features/todos/api/getTodos";
+
+export const getTodosAction = createAsyncThunk<TodoResponse, TodoListParams>(
+  "todo/getTodos",
+  async (input) => {
+    return getTodosApi(input);
+  }
+);
+
+export const buildGetTodosExtraReducer = (
+  builder: ActionReducerMapBuilder<TodoState>
+) => {
+  builder
+    .addCase(getTodosAction.pending, pendingReducer)
+    .addCase(getTodosAction.fulfilled, fulfilledReducer)
+    .addCase(getTodosAction.rejected, rejectedReducer);
+};

--- a/frontend/src/features/todos/stores/reducers/todoExtraReducer.ts
+++ b/frontend/src/features/todos/stores/reducers/todoExtraReducer.ts
@@ -6,18 +6,25 @@ export const pendingReducer = (state: TodoState) => {
   state.inProgress = true;
 };
 
-export const fulfilledReducer = (
+export const addTodoFulfilledReducer = (
   state: TodoState,
   action: PayloadAction<TodoResponse>
 ) => {
   state.inProgress = false;
   state.error = null;
   if (action.payload.todo) {
-    if (Array.isArray(action.payload.todo)) {
-      state.todos = [...state.todos, ...action.payload.todo];
-    } else {
-      state.todos = [...state.todos, action.payload.todo];
-    }
+    state.todos = [...state.todos, action.payload.todo];
+  }
+};
+
+export const addTodosFulfilledReducer = (
+  state: TodoState,
+  action: PayloadAction<TodoResponse>
+) => {
+  state.inProgress = false;
+  state.error = null;
+  if (Array.isArray(action.payload.todos)) {
+    state.todos = [...state.todos, ...action.payload.todos];
   }
 };
 

--- a/frontend/src/features/todos/stores/reducers/todoExtraReducer.ts
+++ b/frontend/src/features/todos/stores/reducers/todoExtraReducer.ts
@@ -6,18 +6,12 @@ export const pendingReducer = (state: TodoState) => {
   state.inProgress = true;
 };
 
-export const addTodoFulfilledReducer = (
-  state: TodoState,
-  action: PayloadAction<TodoResponse>
-) => {
+export const createTodoFulfilledReducer = (state: TodoState) => {
   state.inProgress = false;
   state.error = null;
-  if (action.payload.todo) {
-    state.todoPage.items = [...state.todoPage.items, action.payload.todo];
-  }
 };
 
-export const addTodosFulfilledReducer = (
+export const getTodosFulfilledReducer = (
   state: TodoState,
   action: PayloadAction<TodoResponse>
 ) => {
@@ -25,7 +19,7 @@ export const addTodosFulfilledReducer = (
   state.error = null;
 
   if (Array.isArray(action.payload.items) && action.payload.totalCount) {
-    state.todoPage.items = [...state.todoPage.items, ...action.payload.items];
+    state.todoPage.items = action.payload.items;
     state.todoPage.totalCount = action.payload.totalCount;
   }
 };

--- a/frontend/src/features/todos/stores/reducers/todoExtraReducer.ts
+++ b/frontend/src/features/todos/stores/reducers/todoExtraReducer.ts
@@ -13,7 +13,11 @@ export const fulfilledReducer = (
   state.inProgress = false;
   state.error = null;
   if (action.payload.todo) {
-    state.todos = [...state.todos, action.payload.todo];
+    if (Array.isArray(action.payload.todo)) {
+      state.todos = [...state.todos, ...action.payload.todo];
+    } else {
+      state.todos = [...state.todos, action.payload.todo];
+    }
   }
 };
 

--- a/frontend/src/features/todos/stores/reducers/todoExtraReducer.ts
+++ b/frontend/src/features/todos/stores/reducers/todoExtraReducer.ts
@@ -13,7 +13,7 @@ export const addTodoFulfilledReducer = (
   state.inProgress = false;
   state.error = null;
   if (action.payload.todo) {
-    state.todos = [...state.todos, action.payload.todo];
+    state.todoPage.items = [...state.todoPage.items, action.payload.todo];
   }
 };
 
@@ -23,8 +23,10 @@ export const addTodosFulfilledReducer = (
 ) => {
   state.inProgress = false;
   state.error = null;
-  if (Array.isArray(action.payload.todos)) {
-    state.todos = [...state.todos, ...action.payload.todos];
+
+  if (Array.isArray(action.payload.items) && action.payload.totalCount) {
+    state.todoPage.items = [...state.todoPage.items, ...action.payload.items];
+    state.todoPage.totalCount = action.payload.totalCount;
   }
 };
 

--- a/frontend/src/features/todos/stores/todoSlice.ts
+++ b/frontend/src/features/todos/stores/todoSlice.ts
@@ -6,7 +6,7 @@ import { buildGetTodosExtraReducer } from "./reducers/getTodosReducer";
 
 const initialState: TodoState = {
   inProgress: false,
-  todos: [],
+  todoPage: { items: [], totalCount: 0 },
   error: null,
 };
 

--- a/frontend/src/features/todos/stores/todoSlice.ts
+++ b/frontend/src/features/todos/stores/todoSlice.ts
@@ -2,22 +2,11 @@ import { createSlice } from "@reduxjs/toolkit";
 
 import { buildCreateTodoExtraReducer } from "@/features/todos/stores/reducers/createTodoReducer";
 import type { TodoState } from "@/features/todos/types/todoTypes";
+import { buildGetTodosExtraReducer } from "./reducers/getTodosReducer";
 
 const initialState: TodoState = {
   inProgress: false,
-  todos: [
-    {
-      id: 1,
-      title: "issueを作成",
-      body: "Todo機能のCRUD処理に関する事。",
-    },
-    { id: 2, title: "JS、CSSの勉強", body: "サイトを作成する。" },
-    {
-      id: 3,
-      title: "プログラミング学習",
-      body: "Reactの公式ドキュメントを読む",
-    },
-  ],
+  todos: [],
   error: null,
 };
 
@@ -27,6 +16,7 @@ export const todoSlice = createSlice({
   reducers: {},
   extraReducers(builder) {
     buildCreateTodoExtraReducer(builder);
+    buildGetTodosExtraReducer(builder);
   },
 });
 

--- a/frontend/src/features/todos/types/todoTypes.ts
+++ b/frontend/src/features/todos/types/todoTypes.ts
@@ -8,7 +8,7 @@ interface Todo {
 
 export interface TodoState {
   inProgress: boolean;
-  todos: Todo[];
+  todoPage: { items: Todo[]; totalCount: number };
   error: null | TodoResponseError;
 }
 
@@ -37,6 +37,7 @@ export interface TodoResponse {
     createdAt: Date;
     updatedAt: Date;
   };
-  todos?: Todo[];
+  items?: Todo[];
+  totalCount?: number;
   message?: string[] | string;
 }

--- a/frontend/src/features/todos/types/todoTypes.ts
+++ b/frontend/src/features/todos/types/todoTypes.ts
@@ -17,6 +17,14 @@ export interface TodoInput {
   body: string;
 }
 
+export interface TodoListParams {
+  page?: number;
+}
+
+export interface TodoListProps {
+  todos: Todo[];
+}
+
 export interface TodoResponseError {
   message?: string[] | string;
 }

--- a/frontend/src/features/todos/types/todoTypes.ts
+++ b/frontend/src/features/todos/types/todoTypes.ts
@@ -37,5 +37,6 @@ export interface TodoResponse {
     createdAt: Date;
     updatedAt: Date;
   };
+  todos?: Todo[];
   message?: string[] | string;
 }


### PR DESCRIPTION
コードレビューの方、
よろしくお願いします。

Todoの一覧表示は10件ずつの表示に設定しました。

表示部分は、TodoListコンポーネントを作成し、
こちらにreduxのstoreで管理しているtodosから
10件ずつtodoを取得できるようロジックを構成しました。

useStateとuseEffectを使用し、バックエンドと似たような
変数名を使って実装を行いました。

※バックエンド(リポジトリのlistメソッド)
![スクリーンショット 2025-01-26 223243](https://github.com/user-attachments/assets/a7155bcc-1512-41c9-940e-ea3d0c702d3f)

※フロントエンド
![スクリーンショット 2025-01-26 223431](https://github.com/user-attachments/assets/3d38a534-8f99-449a-b9f4-82d9cc53e4f4)


useStateで管理しているpage数のみクエリで指定し、
オプションのcache: "force-cache"を使用して
ページリロード時にcacheしたデータを表示要素に
使えるようにしました。
![スクリーンショット 2025-01-26 224415](https://github.com/user-attachments/assets/0d39e12a-6723-4818-b1dc-05f019faeeac)



